### PR TITLE
Improve list of upcoming events on homepage

### DIFF
--- a/_includes/events_list_item.html
+++ b/_includes/events_list_item.html
@@ -3,7 +3,7 @@
 {% if site.data.event-categories[event.category] %}
     {% assign categoryInfo = site.data.event-categories[event.category] %}
 {% endif %}
-<div class="media mb-2 event-item" data-date="{{ event.date }}">
+<div class="media mb-2 event-item" data-date="{{ event.date | date: "%F" }}">
     <div class="mr-2 text-center">
         <img src="{{ categoryInfo.image }}" alt="{{ categoryInfo.text }}"/>
         <p style="font-size: 0.8em; width: 80px" >

--- a/_includes/events_list_upcoming.html
+++ b/_includes/events_list_upcoming.html
@@ -1,6 +1,10 @@
-{% assign events = site.events | sort: "date" | reverse %}
+{% assign current_date = site.time | date: '%s' %}
+{% assign events = site.events | sort: "date" %}
 <div class="event-listing event-upcoming">
 {% for evt in events %}
-    {% include events_list_item.html event=evt %}
+    {% assign event_date = evt.date | date: '%s' %}
+    {% if event_date >= current_date %}
+        {% include events_list_item.html event=evt %}
+    {% endif %}
 {% endfor %}
 </div>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,7 +31,7 @@ jQuery(document).ready(function($) {
 	});
 
     /* ======= Upcoming/Previous events ======= */
-    //We assume that events have already been sorted in a reverse chronological order
+    //We assume that events have already been sorted in a reverse chronological order, if headings are being inserted.
     $('.event-listing').each(function(index){
        var eventListing = $(this);
 
@@ -59,7 +59,8 @@ jQuery(document).ready(function($) {
         //Events filtering
         eventListing.find(".event-item").each(function(){
             var eventItem = $(this);
-            var eventDate = moment(eventItem.data("date"));
+            // Throw away part of the date output by jekyll, which under Firefox is not a format recognised by the moment/Date() commands?
+            var eventDate = moment(eventItem.data("date").split(" ")[0]);
 
             if(!displayUpcoming && eventDate.isSameOrAfter(currentTime)){
                 eventItem.remove();
@@ -74,7 +75,7 @@ jQuery(document).ready(function($) {
         if(displayHeaders){
             eventListing.find(".event-item").each(function(){
                 var eventItem = $(this);
-                var eventDate = moment(eventItem.data("date"));
+                var eventDate = moment(eventItem.data("date").split(" ")[0]);
 
                 if(upcomingNotAdded && eventDate.isSameOrAfter(currentTime)){
                     $("<h2>Upcoming Events</h2>").insertBefore(eventItem);
@@ -88,11 +89,6 @@ jQuery(document).ready(function($) {
                 }
             });
         }
-
-
-
-
-
 
     });
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,8 +59,7 @@ jQuery(document).ready(function($) {
         //Events filtering
         eventListing.find(".event-item").each(function(){
             var eventItem = $(this);
-            // Throw away part of the date output by jekyll, which under Firefox is not a format recognised by the moment/Date() commands?
-            var eventDate = moment(eventItem.data("date").split(" ")[0]);
+            var eventDate = moment(eventItem.data("date"));
 
             if(!displayUpcoming && eventDate.isSameOrAfter(currentTime)){
                 eventItem.remove();
@@ -75,7 +74,7 @@ jQuery(document).ready(function($) {
         if(displayHeaders){
             eventListing.find(".event-item").each(function(){
                 var eventItem = $(this);
-                var eventDate = moment(eventItem.data("date").split(" ")[0]);
+                var eventDate = moment(eventItem.data("date"));
 
                 if(upcomingNotAdded && eventDate.isSameOrAfter(currentTime)){
                     $("<h2>Upcoming Events</h2>").insertBefore(eventItem);


### PR DESCRIPTION
Upcoming events are listed in chronological order, rather than reverse chrono.
The Javascript which filters out past-events has been modified that it behaves as intended in Firefox.
The homepage list has been filtereted to not output the html for past-events (at the time of compilation).

Closes #53