### PR TITLE
Place homepage intro text alongside logo on large enough screens.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,27 +6,27 @@ layout: default
 <section id="promo" class="promo section offset-header">
     <div class="container text-center">
 
-        <div class="text-center">
-
-            <svg width="600" height="300" class="img-fluid" viewBox="0 0 600 300">
-                <title>Research Software Engineering Sheffield</title>
-                <image xlink:href="/assets/images/rse-logoonly-stroke.png" x="0" y="0" height="250px" width="250px"/>
-                <text x="250" y="20" font-family="tuos_stephensonbold" font-size="3.3em" fill="white">
-                    <tspan x="250" dy=".6em">Research</tspan>
-                    <tspan x="250" dy="1.2em">Software</tspan>
-                    <tspan x="250" dy="1.2em">Engineering</tspan>
-                    <tspan x="250" dy="1.2em">Sheffield</tspan>
-                </text>
-            </svg>
+        <div class="row">
+            <div class="col-sm-offset-1 col-sm-10 col-md-5 col-lg-5 col-xl-4">
+                <div class="text-center">
+                    <svg width="600" height="300" class="img-fluid" viewBox="0 0 600 300">
+                        <title>Research Software Engineering Sheffield</title>
+                        <image xlink:href="/assets/images/rse-logoonly-stroke.png" x="0" y="0" height="250px" width="250px"/>
+                        <text x="250" y="20" font-family="tuos_stephensonbold" font-size="3.3em" fill="white">
+                            <tspan x="250" dy=".6em">Research</tspan>
+                            <tspan x="250" dy="1.2em">Software</tspan>
+                            <tspan x="250" dy="1.2em">Engineering</tspan>
+                            <tspan x="250" dy="1.2em">Sheffield</tspan>
+                        </text>
+                    </svg>
+                </div>
+            </div>
+            <div class="col-xs-12 col-md-7 col-lg-7 col-xl-8">
+                <p class="intro" style="font-family: tuos_stephensonbold">
+                    Research Software Engineers (RSEs) are the people behind research software. This website is designed as a hub for Sheffield academics seeking help with research software and as a community for research software engineers.
+                </p>
+            </div>
         </div>
-
-
-
-
-
-        <p class="intro" style="font-family: tuos_stephensonbold">
-            Research Software Engineers (RSEs) are the people behind research software. This website is designed as a hub for Sheffield academics seeking help with research software and as a community for research software engineers.
-        </p>
     </div><!--//container-->
     <div class="social-media">
         <div class="social-media-inner container text-center">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3,6 +3,15 @@
  * Separate from the theme rules in-case we change theme
  */
 
+/*
+    Bootstrap breakpoints for reference:
+    xs 
+    sm @media (min-width:576px)
+    md @media (min-width:768px)
+    lg @media (min-width:992px)
+    xl @media (min-width:1200px)
+*/
+
 .seminar-section {
     margin-bottom: 2rem;
     padding-bottom: 1rem;
@@ -13,4 +22,10 @@
 img {
     max-width: 100%;
     height: auto;
+}
+
+@media (min-width: 768px) and (max-width: 991px){
+    .promo .intro {
+        font-size: 18px;
+    }
 }


### PR DESCRIPTION
Reduces the font size on md displays (768 <= width <= 991px) to match vertical height.

Closes #57