### PR TITLE
Append trailng / to blog permalinks.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ defaults:
       path: "_posts"
     values:
       layout: "post"
-      permalink: "/blog/:slug"
+      permalink: "/blog/:slug/"
   - scope:
       path: ""
       type: "events"


### PR DESCRIPTION
This should resolve #86 but we won't know for sure until merge.

It is promising however, as the output of a jekyll build produces blog/post/index.html rather than blog/post.html as before (local jekyll server behaves correctly before and after)