### PR TITLE
Event ordering

### DIFF
--- a/_includes/events_list_item.html
+++ b/_includes/events_list_item.html
@@ -3,7 +3,7 @@
 {% if site.data.event-categories[event.category] %}
     {% assign categoryInfo = site.data.event-categories[event.category] %}
 {% endif %}
-<div class="media mb-2 event-item" data-date="{{ event.date | date: "%F" }}">
+<div class="media mb-2 event-item" data-date="{{ event.date | date: "%F" }}{% if event.to %}{{event.to | date: " %H:%M:%S"}}{% endif %}">
     <div class="mr-2 text-center">
         <img src="{{ categoryInfo.image }}" alt="{{ categoryInfo.text }}"/>
         <p style="font-size: 0.8em; width: 80px" >

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,3 +29,11 @@ img {
         font-size: 18px;
     }
 }
+
+/* Visually distinguish past events.*/
+.event-item-previous a {
+    color: #656565;
+}
+.event-item-previous > div >img {
+    opacity: 0.40;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -38,6 +38,7 @@ jQuery(document).ready(function($) {
        var displayUpcoming = true;
        var displayPrevious = true;
        var displayHeaders = false;
+       var chronologicalUpcoming = true;
 
         if(eventListing.hasClass("event-upcoming-previous")){
            displayUpcoming = true;
@@ -60,7 +61,7 @@ jQuery(document).ready(function($) {
         eventListing.find(".event-item").each(function(){
             var eventItem = $(this);
             var eventDate = moment(eventItem.data("date"));
-
+            
             if(!displayUpcoming && eventDate.isSameOrAfter(currentTime)){
                 eventItem.remove();
             }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -61,13 +61,21 @@ jQuery(document).ready(function($) {
         eventListing.find(".event-item").each(function(){
             var eventItem = $(this);
             var eventDate = moment(eventItem.data("date"));
-            
-            if(!displayUpcoming && eventDate.isSameOrAfter(currentTime)){
-                eventItem.remove();
+
+            if(eventDate.isSameOrAfter(currentTime)){
+                if(displayUpcoming){
+                    eventItem.addClass("event-item-upcoming");
+                } else {
+                    eventItem.remove();
+                }
             }
 
-            if(!displayPrevious && eventDate.isBefore(currentTime)){
-                eventItem.remove();
+            if(eventDate.isBefore(currentTime)){
+                if(displayPrevious){
+                    eventItem.addClass("event-item-previous");
+                } else {
+                    eventItem.remove();
+                }
             }
         });
 
@@ -78,16 +86,30 @@ jQuery(document).ready(function($) {
                 var eventDate = moment(eventItem.data("date"));
 
                 if(upcomingNotAdded && eventDate.isSameOrAfter(currentTime)){
-                    $("<h2>Upcoming Events</h2>").insertBefore(eventItem);
+                    $('<h2 id="upcoming">Upcoming Events</h2>').insertBefore(eventItem);
                     upcomingNotAdded = false;
 
                 }
 
                 if(prevNotAdded && eventDate.isBefore(currentTime)){
-                    $("<h2>Previous Events</h2>").insertBefore(eventItem);
+                    $('<h2 id="previous">Previous Events</h2>').insertBefore(eventItem);
                     prevNotAdded = false;
                 }
             });
+        }
+
+        // Make upcoming events in forward chronological order, rather than reverse chronological order.
+        if(displayUpcoming && displayHeaders && chronologicalUpcoming){
+            // Get the location of the upcoming header as an anchor.
+            var anchorElement = document.getElementById("upcoming");
+            if(anchorElement){
+                // For each upcoming element, move it to after the heading. 
+                // As elements are in reverse-chrono order, the order of execution results in forward chrono order.
+                eventListing.find(".event-item-upcoming").each(function(){
+                    var eventItem = $(this);
+                    anchorElement.insertAdjacentElement('afterend', this);
+                });
+            }
         }
 
     });


### PR DESCRIPTION
+ Show events up until the end of their "To" field. 
    + Closes #97 
+ Order upcoming events in forward chronological order
    + Reverse chrono for previous event still. 
+ Visually distinguish previous events
    + `#656565` urls and reduced opacity icons.
    + Closes #35 

![image](https://user-images.githubusercontent.com/628937/56673622-813c4a00-66b0-11e9-959f-880e412a1428.png)
