### PR TITLE
Remove un-neccesary <hr> elements from templates

### DIFF
--- a/_includes/dltraining_individual.html
+++ b/_includes/dltraining_individual.html
@@ -24,8 +24,6 @@
     </figure>
     {% endif %}
 
-    <hr />
-
     {% endif %}
 
 </section>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -56,8 +56,6 @@ layout: default
 
                     {% endif %}
 
-                    <hr />
-
                 </section>
             </div>
         </div>


### PR DESCRIPTION
Hrs were being used for stylistic reasons, which had been replaced with CSS. Some <hr>s were missed, so there were duplicate cosmetic lines.