### PR TITLE
Fix google calendar embed

### DIFF
--- a/_layouts/codeclinic.html
+++ b/_layouts/codeclinic.html
@@ -9,7 +9,7 @@ layout: page
         {{ content }}
     </div>
     <div class="col-3">
-        <iframe src="https://calendar.google.com/calendar/b/1/embed?title=RSE%20Code%20Clinic%20Calendar&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=2&amp;bgcolor=%23ccffff&amp;src=sheffield.ac.uk_28d0d6953rcq30teo2rapepho0%40group.calendar.google.com&amp;color=%238C500B&amp;ctz=Europe%2FLondon" style="border-width:0" width="400" height="600" frameborder="0" scrolling="no"></iframe>
+        <iframe src="https://calendar.google.com/calendar/embed?title=RSE%20Code%20Clinic%20Calendar&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=2&amp;bgcolor=%23ccffff&amp;src=sheffield.ac.uk_28d0d6953rcq30teo2rapepho0%40group.calendar.google.com&amp;color=%238C500B&amp;ctz=Europe%2FLondon" style="border-width:0" width="400" height="600" frameborder="0" scrolling="no"></iframe>
     </div>
 
 </div>


### PR DESCRIPTION
The /b/1/ in the URL meant that if you were logged into 2 google accounts, the 1st account (not 0th) required access.
If we try /b/0 then it only works if the 0th account has access.

Without /b/N/ in the URL it appears to try all accounts - i.e. it works with my shef.ac.uk account as either 0th or 1st.

Fixes #103