### PR TITLE
Issue143

### DIFF
--- a/_layouts/codeclinic.html
+++ b/_layouts/codeclinic.html
@@ -3,14 +3,5 @@ layout: page
 ---
 
 
-<div class="row">
-
-    <div class="col-9">
-        {{ content }}
-    </div>
-    <div class="col-3">
-        <iframe src="https://calendar.google.com/calendar/embed?title=RSE%20Code%20Clinic%20Calendar&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=600&amp;wkst=2&amp;bgcolor=%23ccffff&amp;src=sheffield.ac.uk_28d0d6953rcq30teo2rapepho0%40group.calendar.google.com&amp;color=%238C500B&amp;ctz=Europe%2FLondon" style="border-width:0" width="400" height="600" frameborder="0" scrolling="no"></iframe>
-    </div>
-
-</div>
+{{ content }}
 

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -20,10 +20,6 @@ advise,
 troubleshoot and 
 suggest ways to improve your computational workflows**.
 
-### When: Every second Wed (14:00 - 16:00)
-
-Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that. Note that **slots can only be booked 48 hours or more before the scheduled time**.
-
 ### Where: Room COM-G25
 
 [Regent Court, Dept. of Computer Science, The University of Sheffield, 211 Portobello, Sheffield, S1 4DP](https://goo.gl/maps/t88GdT9Yjmz).
@@ -42,7 +38,11 @@ Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that. N
 
 **We can help!**
 
-### Booking a session
+### When: Every second Wed (14:00 - 16:00)
+
+Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that.
+
+### Book a slot
 
 Clinic sessions are split into 3 half-hourly slots, bookable for consultation. 
 To book, please **fill in this [brief form](https://goo.gl/forms/5MVy0jM6xQhWlpmn1).**

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -23,9 +23,6 @@ suggest ways to improve your computational workflows**.
 ### When: Every second Wed (14:00 - 16:00)
 
 Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that. 
-Check for scheduled dates on the RSE [**Code Clinic** calendar](#calendar).
-Note that **slots can only be booked 48 hours or more before the scheduled time**.
-
 
 ### Where: Room COM-G25
 

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -22,7 +22,7 @@ suggest ways to improve your computational workflows**.
 
 ### When: Every second Wed (14:00 - 16:00)
 
-Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that. 
+Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that. Note that **slots can only be booked 48 hours or more before the scheduled time**.
 
 ### Where: Room COM-G25
 


### PR DESCRIPTION
Resolves issue #143, for the time being, by removing the intermittently broken calendar widget and related link. Slot times are visible on the booking form.