### PR TITLE
CI error on frontmatter and fix post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+strict_front_matter: true
 defaults:
   -
     scope:

--- a/_events/event-2019-10-02-slt-cdt-talk.md
+++ b/_events/event-2019-10-02-slt-cdt-talk.md
@@ -7,7 +7,7 @@ date: 2019-10-02
 from: "11:30"
 to: "12:00"
 location: "Computer Science, University of Sheffield"
-speaker: "Will Furnass
+speaker: "Will Furnass"
 institute: "University of Sheffield"
 ---
 


### PR DESCRIPTION
+ Sets Jekyll to return non zero code on frontmatter errors, triggering a CI failure.
+ Fixes YAML frontmatter issue in CDT post (missing `"`)


Resolves #150 