### PR TITLE
Pagination of Blog Posts

### DIFF
--- a/_data/projects.csv
+++ b/_data/projects.csv
@@ -5,7 +5,7 @@ id,key,title,long_title,tech_methods,rses,start,end,department,level,show
 6,,Strituvad,Strituvad,,"Peter Heywood, David Wilby",16/04/2018,01/11/2021,Mathematics and Statistics,2,1
 7,,BBSRC: Cell Modelling,BBSRC: Cell Modelling,,Twin Karmakharm,01/10/2018,30/09/2021,Mathematics and Statistics,2,1
 8,,CompBioMed2,CompBioMed2,,Daniele Tartarini,01/10/2019,30/09/2023,INSIGNEO,2,1
-9,,Primage,Primage,,Robert Chisholm,01/01/2019,31/12/2022,INSIGNEO,2,1
+9,primage,Primage,Primage,,Robert Chisholm,01/01/2019,31/12/2022,INSIGNEO,2,1
 10,,Google DNI Journalist,Google DNI Journalist,,"David Jones, Twin Karmakharm",01/01/2019,01/01/2020,Computer Science,2,1
 11,,ELG,ELG,,David Jones,07/01/2019,01/01/2020,Computer Science,2,1
 12,,BRC,BRC,"databases, ansible, training, matlab, R, REDCap, XNAT, servers","Anna Krystalli, Will Furnass, Robert Turner",01/05/2018,31/03/2022,INSIGNEO,2,1

--- a/_project_descriptions/primage.md
+++ b/_project_descriptions/primage.md
@@ -1,0 +1,13 @@
+---
+key: primage
+---
+
+[PRIMAGE](https://www.primageproject.eu/) (PRedictive In-silico Multiscan Analytics to support cancer personalised diaGnosis and prognises, Empowered by imaging biomarkers) is an EU financed collaboration between 16 partners to develop an open cloud-based platform to support decision making int he clinical management of two paediatric cancers, Neuroblastoma (NB), the most frequent solid cancer of early childhood, and the Diffuse Intrinsic Pontine Glioma (DIPG) the leading cause of brain tumour-related death in children.
+
+RSEs have been working closely with the Sheffield team on the project to develop a highly scalable CUDA GPU parallel cell-level model of a Neuroblastoma tumour. Parallel development has been used, whereby an RA with understanding of the biological processes has developed a model using their language of choice (Python), each incremental change to the model has then been transfered to a separate CUDA implementation of the model using [FLAMEGPU](http://www.flamegpu.com/) and validated for consistent behaviour with the original implementation.
+
+The separation of concerns, has allowed the modeller to focus on the correctness of their model rather than performance. Whilst the RSE developed CUDA model has made it practical to model tumours 10,000+ times larger, enabling much faster access to model calibration and parameter sweep results.
+
+The partnership has also allowed technical concerns regarding integration of the Sheffield model with the wider consortium's models to be offloaded to the RSE team.
+
+RSE involvement in this project has also supported development of [FLAMEGPU2](https://github.com/FLAMEGPU/FLAMEGPU2), which aims to provide a more-accessible (Python and C++) interface to highly-scalable CUDA GPU parallel modelling of complex systems.


### PR DESCRIPTION
Addresses issue #6 

Demo visible here: [https://rse-mirror.robadob.org/blog](https://rse-mirror.robadob.org/blog).

After discussing with @willfurnass, agreed to switch to a traditional blog format, whereby main blog page shows [excerpts](https://jekyllrb.com/docs/posts/#post-excerpts) from posts, and links to the full post. It currently shows 6 per page, but this can be changed easily via `_config.yml`.

To manage this, you need to additionally include `excerpt_separator: <!--more-->` in the front matter, and then place your separator (e.g. `<!--more-->`) somewhere in the body of your post. Everything above that separator will appear above the fold. If this isn't included, it appears to simply treat the first blank line as the separator. I have/will go back and tweak all historic posts to support this, and add perhaps add a note to the RSE handbook.

## Changelog:
* Changed title from 'Blog' to 'RSE Sheffield Blog'
* Moved old blog page permalink from `/blog` to `/blog/all`
* Created new blog page which displays 6 excerpts with links through to full article
   * Added CSS rule to nudge down heading sizes within excerpts
* Added CSS rules for paginate buttons/hr separator
   * Pagination links includes a small link below to directory of pages (`/blog/all`).
* Replaced post page paginate buttons with same style as blog page
* Adjusted all old blog posts to include manual excerpt breaks