### PR TITLE
Adds custom 404 page to the website

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,12 @@
+---
+layout: page
+type: text
+permalink: /404.html
+---
+
+# 404 - Page not found
+
+Sorry, the page you are looking for does not exist. 
+
+
+[Return to our homepage]({{ site.url }}).


### PR DESCRIPTION
For the github pages server configuration, this needs to be in the root of the repository as 404.md or 404.html.

For locally served copies, the jekyll serve command does not handle 404s, so visit /404/ to test the page.

Closes #161