### PR TITLE
404 duplicate title fix

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,12 +1,10 @@
 ---
 layout: page
 type: text
+title: 404 - Page not found
 permalink: /404.html
 ---
 
-# 404 - Page not found
-
 Sorry, the page you are looking for does not exist. 
-
 
 [Return to our homepage]({{ site.url }}).

--- a/Gemfile
+++ b/Gemfile
@@ -9,14 +9,14 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.6.3"
+# gem "jekyll", "3.6.3"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 #gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do


### PR DESCRIPTION
Fixes the duplicate tiltle caused by a default github pages plugin. 

Also switches the gemfile to require the `github-pages` gem rather than standalone `jekyll`.
This will ensure that local builds (and travis builds) will use the same version of jekyll and default plugins as used by github-pages builds. 

Closes #164 