### PR TITLE
Remote code clinics

### DIFF
--- a/_posts/2020-03-17-code-clinics-online.md
+++ b/_posts/2020-03-17-code-clinics-online.md
@@ -11,7 +11,7 @@ description:
 type: text
 ---
 
-In response to the need for increased remote working, we're going to be doing our [Code Clinics](/support/code-clinic) remotely using Google Hangouts for now.
+In response to the need for increased remote working as a result of the current Covid-19 situation, we're going to be doing our [Code Clinics](/support/code-clinic) remotely using Google Hangouts for now.
 
 Code Clinics remain a great way to get help with writing and maintaining code and with reduced physical access to labs, perhaps now is good time to focus on this aspect of research. **We can offer advice on working with and executing code remotely.**
 

--- a/_posts/2020-03-17-code-clinics-online.md
+++ b/_posts/2020-03-17-code-clinics-online.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: Remote Code Clinics
+author: Robert (Bob) Turner
+slug: 2020-03-17-code-clinics-online
+date: 2020-03-17 12:00:00 UTC
+tags: support
+category:
+link:
+description:
+type: text
+---
+
+In response to the need for increased remote working, we're going to be doing our [Code Clinics](/support/code-clinic) remotely using Google Hangouts for now.
+
+Code Clinics remain a great way to get help with writing and maintaining code and with reduced physical access to labs, perhaps now is good time to focus on this aspect of research. **We can offer advice on working with and executing code remotely.**
+
+We'll do our best to help with:
+
+- Short scripts
+- Complicated spreadsheets
+- Version control
+- Databases
+- Jupyter notebooks
+- R markdown
+- Getting code onto HPC
+- Debugging
+- Performance problems
+- Anything else vaguely code-related, if we can!
+
+*Code Clinics from the RSE Team are part of a range of IT, maths and data support services run by the University of Sheffield for researchers. We will direct you to our colleagues if they're more a more appropriate source of help for a particular issue, and they will do likewise.*

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -6,23 +6,18 @@ slug: code-clinic
 type: text
 ---
 
+> Code clinics will be done online using Google Hangouts for the foreseeable future.
 
 *Stop wasting valuable time trying to fix issues on your own.*
 
-
-Code Clinics are research software engineering (RSE) **fortnightly support sessions** run by **RSE@Sheffield**. 
-They are open to **anyone at TUoS writing code for research** to 
-get help with programming problems and general advice on best practice.
+Code Clinics are research software engineering (RSE) **fortnightly support sessions** run by **RSE@Sheffield**. They are open to **anyone at TUoS writing code for research** to  get help with programming problems and general advice on best practice.
 
 At each session, **members of the RSE team will be available to 
-review code, 
-advise, 
-troubleshoot and 
-suggest ways to improve your computational workflows**.
+review code, advise, troubleshoot and suggest ways to improve your computational workflows**.
 
-### Where: Room COM-G25
+### Where?
 
-[Regent Court, Dept. of Computer Science, The University of Sheffield, 211 Portobello, Sheffield, S1 4DP](https://goo.gl/maps/t88GdT9Yjmz).
+A Google Hangouts link will be provided.
 
 ### Who: Are you...
 

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -6,7 +6,7 @@ slug: code-clinic
 type: text
 ---
 
-> Code clinics will be done online using Google Hangouts for the foreseeable future.
+> Code clinics will be done online using Google Hangouts for the foreseeable future due to the current Covid-19 situation.
 
 *Stop wasting valuable time trying to fix issues on your own.*
 

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -17,7 +17,7 @@ review code, advise, troubleshoot and suggest ways to improve your computational
 
 ### Where?
 
-A Google Hangouts link will be provided.
+A Google Hangouts link will be provided in the Google Calendar invite issued when you book a clinic.
 
 ### Who: Are you...
 


### PR DESCRIPTION
This PR modifies the text on the code clinics page and adds a blog post reiterating what code clinics are and explaining why and how we're going remote.