### PR TITLE
Re-enable link checking in Travis CI jobs with htmlproofer

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -2,4 +2,11 @@
 set -e # halt script on error
 
 bundle exec jekyll build
-#bundle exec htmlproofer --allow-hash-href ./_site
+bundle exec htmlproofer \
+    --file-ignore="/\/node_modules\//" \
+    --checks-to-ignore=ScriptCheck,ImageCheck \
+    --disable-external \
+    --internal-domains shef.ac.uk,sheffield.ac.uk,insigneo.org \
+    --alt-ignore=assets/* \
+    --allow-hash-href \
+    _site


### PR DESCRIPTION
As discussed in #239 with @twinkarma