### PR TITLE
Remove mention of 2018 from Code Clinic page

### DIFF
--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -39,9 +39,9 @@ A Google Meet link will be provided in the Google Calendar invite issued when yo
 
 **We can help!**
 
-### When: Every second Wed (14:00 - 16:00)
+### When
 
-Clinics launch on **Wednesday, Oct 3rd, 2018** and run fortnightly after that.
+Every second Wednesday (14:00 - 16:00).
 
 ### Book a slot
 

--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -41,7 +41,7 @@ A Google Meet link will be provided in the Google Calendar invite issued when yo
 
 ### When
 
-Every second Wednesday (14:00 - 16:00).
+Every second Wednesday (13:30 - 15:30).
 
 ### Book a slot
 


### PR DESCRIPTION
Kinda hints that this page hasn't been updated for a while and the
Clinic may no longer be running.