### PR TITLE
Add more N8 CIR events

### DIFF
--- a/_events/event-2020-05-28-n8-cir-meetup.md
+++ b/_events/event-2020-05-28-n8-cir-meetup.md
@@ -1,0 +1,18 @@
+---
+title: N8 CIR Meet-Ups – N8 CIR RSE Highlights
+category: seminar
+tags:
+permalink: /training/workshop/2020-05-28-n8-cir-meetup/
+date: 2020-05-28
+from: "15:00"
+to: "16:00"
+location: "Online"
+speaker: "TBC"
+institute: "N8"
+---
+
+A set of four short talks from research software engineers working within the N8 Research Partnership.
+Full details of the speakers are yet to be confirmed.
+
+Full details will be published here closer to the event:
+[https://n8cir.org.uk/events/n8-cir-meet-ups-3/](https://n8cir.org.uk/events/n8-cir-meet-ups-3/)

--- a/_events/event-2020-06-04-n8-cir-meetup.md
+++ b/_events/event-2020-06-04-n8-cir-meetup.md
@@ -1,0 +1,18 @@
+---
+title: N8 CIR Meet-Ups – RSE Career Progression
+category: seminar
+tags:
+permalink: /training/workshop/2020-06-04-n8-cir-meetup/
+date: 2020-06-04
+from: "15:00"
+to: "16:00"
+location: "Online"
+speaker: "Mark Turner"
+institute: "N8"
+---
+
+In this session Mark Turner (University of Newcastle) will explain some of the work done with Human Resources departments to set roles and responsibilities for each job grade from new RSEs to group leaders. 
+There will also be feedback from senior RSEs who have sat on interview panels.
+
+Find out more here: 
+[https://n8cir.org.uk/events/n8-cir-meet-ups-4/](https://n8cir.org.uk/events/n8-cir-meet-ups-4/)

--- a/_events/event-2020-06-11-n8-cir-meetup.md
+++ b/_events/event-2020-06-11-n8-cir-meetup.md
@@ -1,0 +1,17 @@
+---
+title: N8 CIR Meet-Ups – N8 CIR RSE Highlights
+category: seminar
+tags:
+permalink: /training/workshop/2020-06-11-n8-cir-meetup/
+date: 2020-06-11
+from: "15:00"
+to: "16:00"
+location: "Online"
+speaker: "TBC"
+institute: "N8"
+---
+
+A set of four short talks from research software engineers working within the N8 Research Partnership.
+Full details of the speakers are yet to be confirmed.
+Full details will be published here closer to the event:
+[https://n8cir.org.uk/events/n8-cir-meet-ups-5/](https://n8cir.org.uk/events/n8-cir-meet-ups-5/)

--- a/_events/event-2020-06-18-n8-cir-meetup.md
+++ b/_events/event-2020-06-18-n8-cir-meetup.md
@@ -1,0 +1,20 @@
+---
+title: N8 CIR Meet-Ups – RSE Speed Blogging
+category: workshop
+tags:
+permalink: /training/workshop/2020-06-18-n8-cir-meetup/
+date: 2020-06-18
+from: "15:00"
+to: "16:00"
+location: "Online"
+speaker: "Kirsty Pringle, Alison Clarke and Marion Weinzierl"
+institute: "N8"
+---
+
+Speed blogging events are fun, interactive and engaging sessions.
+Participants work in small groups to document ideas, opinions and challenges.
+It is a great way to get to know other RSEs, share ideas and have a chance to get a voice.
+This session will be led by Kirsty Pringle from the University of Leeds
+with additional support from Alison Clarke and Marion Weinzierl, both from Durham University.
+
+Register here: [https://n8cir.org.uk/events/n8-cir-meet-ups-6/](https://n8cir.org.uk/events/n8-cir-meet-ups-6/)

--- a/_events/talk-2020-05-21-bede-n8cir-intro.md
+++ b/_events/talk-2020-05-21-bede-n8cir-intro.md
@@ -4,9 +4,9 @@ date: 2020-05-21
 published: true
 from: "15:00"
 to: "16:00"
-location: "Online @ 'Research reproducibility and good practice in statistical software', RSS Leeds / Bradford Local Group Seminar"
+location: "Online"
 speaker: "Alan Real and Paul Richmond"
-institute: "University of Sheffield"
+institute: "N8"
 title: "Introducing the N8 Bede GPU HPC cluster"
 ---
 


### PR DESCRIPTION
Promotion of events listed here: https://n8cir.org.uk/news/meet-ups-2020/

I also updated the location of the Intro to Bede workshop tomorrow as it had been incorrectly copied from another event posting. 