### PR TITLE
Generate newsletters feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,3 +75,9 @@ defaults:
       type: "newsletters"
     values:
       layout: "newsletter"
+
+# RSS feeds in addition to "posts"
+feed:
+  collections:
+    newsletters:
+      path: 'feed/newsletters.xml'


### PR DESCRIPTION
While newsletters are still there own separate collection, they generate their own rss feed to subscribe to (in this case /newsletters.xml). Addresses #279 