### PR TITLE
August 2020 Newsletter.

### DIFF
--- a/_newsletters/2020-07-03-newsletter.md
+++ b/_newsletters/2020-07-03-newsletter.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: August 2020 Newsletter
+editor: Robert Chisholm
+slug: 2020-08-01-newsletter
+date: 2020-08-01 12:00:00 UTC
+tags: 
+category:
+link:
+description:
+type: text
+---
+
+## University of Sheffield Research Software Engineering Team Newsletter August 2020
+
+Welcome to the 2nd monthly newsletter! The aim is to provide you with a monthly guide to events and news relevant to research software development, including content from outside our team.
+
+If you'd like the newsletter delivered to your inbox for maximum convenience, please sign up to our [Google Group](https://groups.google.com/a/sheffield.ac.uk/forum/#!forum/rse-group).
+
+### Events
+
+With many taking annual leave during August, events this month are limited. We hope to see more in September!
+
+* [NAG](https://www.nag.com/) are running 5 [free masterclasses on algorithmic differentiation](https://register.gotowebinar.com/register/4596799038835429135). Between July 30th and August 27th, the first has already passed but you can still register for the remaining classes.
+* [Carpentry Con@Home](https://2020.carpentrycon.org/schedule) continues to run all through August, this free online conference has a variety of events covering; git, co-development, avoiding burnout and much more!
+* LunchBytes: Writing safer Python code -  September 9th 2020 12:00-13:00 *(More details below)*
+* [Gaussian Process Summer School](http://gpss.cc/gpss20/): Learn about Gaussian Processes with experts from the University of Sheffield and beyond - September 14th 2020 to September 17th 2020
+
+#### Lunchbytes
+
+A new monthly series of short talks on research computing, data workflows, and infrastructure.  The first session is to be on 9th September 2020 12:00-13:00 and is themed around *writing safer Python code*:
+
+ - Type Annotations - how to reduce the risk of passing the wrong type of argument to functions (Joe Heffer, IT Services)
+ - Automatable testing of code using pytest (David Jones, RSE team)
+ - Writing safer functions that are easier to reason about (Will Furnass, RSE team)
+
+Each talk will be ~10 minutes, leaving half an hour for discussion/questions.
+
+You'll notice that all presenters are from IT Services or the RSE team; in future we hope that people from the research community feel able to either *request* LunchBytes talks from others or *offer* LunchBytes talks on topics they find interesting.  We'll tell you more about the mechanisms for making requests / offering talks at the first meetup!
+
+Sign up to our [mailing list](https://groups.google.com/a/sheffield.ac.uk/forum/#!forum/rse-group) to be notified of Blackboard Collaborate joining instructions!
+
+### Opportunities
+
+* EPSRC [Research Software Engineer (RSE) Fellowships](https://epsrc.ukri.org/funding/calls/pre-announcement-for-research-software-engineer-rse-fellowships/) August 18th 2020 deadline
+* EPSRC [Call for Access to High Performance Computing (HPC)](https://epsrc.ukri.org/funding/calls/access-to-high-performance-computing/) September 4th 2020 deadline.
+* A new initiative [SORSE](https://sorse.github.io/) was launched in July, with the intent to deliver weekly online content for RSEs to develop skills and collaborate. Abstracts for proposed events can be submitted [here](https://sorse.github.io/programme/call-for-contributions/). We can expect to see them begin to schedule events at the end of summer, their programme already lists several upcoming topics:
+    * [Configuring Sphinx from scratch: making your own documentation](https://sorse.github.io/programme/software-demos/event-011/)
+    * [Help! I’m a Research Software Manager!](https://sorse.github.io/programme/talks/event-005/)
+    * [Towards an NLP Pipeline for Conflict Narrative Detection](https://sorse.github.io/programme/talks/event-006/)
+    * [*and more...*](https://sorse.github.io/programme/)
+* [UKRI Coronavirus Hub](https://www.ukri.org/research/coronavirus/) - Collaborations between RSEs and academics can be very productive ways of developing epidemiological models.
+
+### Web and Blogs
+
+* [A retrospective look at the N8 ReproHack that took place in May](https://n8cir.org.uk/events/event-resource/reprohack/). This research reproducibility event was moved online due to the pandemic, enabling participants outside the UK to join.
+* [Anna Krystalli](https://twitter.com/annakrystalli) from our team recently delivered a keynote to the useR! conference, the main annual meeting of the R community. ([Video](https://www.youtube.com/watch?v=KHMW8fV2NXo)|[Slides](https://annakrystalli.me/talks/user2020.html))
+* [Tom Stafford](https://twitter.com/tomstafford/status/1285844465727438850), a lecturer in Psychology and Cognitive Science and research practice lead, has put together a [showcase of the data visualisations](https://tomstafford.github.io/psy6422/class-of-2020.html) produced by his students.
+
+### Training Resources
+
+* IT Services: Research provides [training in a range of research software related areas](https://www.sheffield.ac.uk/it-services/research/training).
+* The Library’s Scholarly Communications Team provides [training and support for data management planning](https://www.sheffield.ac.uk/library/rdm/training).
+* Keen to learn R from the comfort of your home? [Online R training](https://sbc.shef.ac.uk/training/r-introduction-online/) from the Sheffield Bioinformatics Core may be the answer!
+* Twin Karmakharm from the RSE team has put together a [list of online training resources](https://rse.shef.ac.uk/training/programming), mainly around **Python** and **git**.
+
+If you think there are other great training resources we should advertise, please get in [contact](rse-team-group@sheffield.ac.uk).
+
+### Sheffield RSE Team Services
+
+The RSE team aims to collaborate with you to help improve your research software. We can provide dedicated staff to ensure that you can deliver excellent research software engineering on your research projects.
+
+The RSE team provides free [Code clinics](https://rse.shef.ac.uk/support/code-clinic/) and [paid services](https://rse.shef.ac.uk/service/) allowing us to collaborate longer term.


### PR DESCRIPTION
Plan is to send it out on Monday.
Few minor additions which might happen before then.

Notes:
* Intro
    * Has been rewritten.
* Events
    * Checked a few places e.g. N8 diary, SORSE calendar, all I could find scheduled for August onwards was NAG AD masterclasses. I'm assuming this is a consequence of summer, rather than my incompetence.
* Opportunities
    * Added SORSE
    * Added ESPRC call for HPC
    * Moved UKRI Corona hub to the end (it lacks a deadline).
* 'Web and Blogs'
    * All links are new, could do with adding a couple more (no blog posts from our team this month?).
* Training
    * Moved to second last section of newsletter. This is unchanged, all items are links to webpages without a schedule/deadline.
    * Renamed training resources, training events can go in the normal events section as there's a big grey area between which events are training and which aren't.

TODO:
* @willfurnass Suggested he wanted to write a brief bit for his Lunchbytes session
* Really would like to find a couple more new webby/blog links.