### PR TITLE
Fix a few links which were using link:/ which is not valid in jekyll

### DIFF
--- a/_posts/2017-03-12-icms-2017.md
+++ b/_posts/2017-03-12-icms-2017.md
@@ -13,7 +13,7 @@ type: text
 Back in mid-January three members of the University of Sheffield's
 Research Software Engineering Team (me, [Mike
 Croucher](/contact/alumni//) and [Tania
-Allard](link://slug/tania_allard)) spent a week at a [Computational
+Allard](/contact/tania-allard/)) spent a week at a [Computational
 Mathematics with Jupyter
 workshop](https://opendreamkit.org/meetings/2017-01-16-ICMS/), hosted at
 Edinburgh's [International Centre for Mathematical

--- a/_posts/2017-03-20-sge-job-validation.md
+++ b/_posts/2017-03-20-sge-job-validation.md
@@ -10,8 +10,8 @@ description:
 type: text
 ---
 
-(**Edit**: caveats are listed in a [more recent post](link://slug/sge-job-validation-2))
-
+(**Edit**: caveats are listed in a [more recent post]({% post_url 2017-04-19-sge-job-validation-2 %})
+    
 Computer cluster job scheduling software is fantastic at managing resources 
 and permitting many jobs to run efficiently and simultaneously.  
 However, schedulers aren't always great at giving end-users feedback 
@@ -107,7 +107,7 @@ You may ask why such validation is not enabled by default for all jobs;
 one reason for this is that it is believed it would place undue burden on the scheduler.
 
 Another is that sometimes a validation attempt results in a false negative that can be difficult to automatically identify
-(**edit**: see this [more recent post](link://slug/sge-job-validation-2) for details).
+(**edit**: see this [more recent post]({% post_url 2017-04-19-sge-job-validation-2 %}) for details).
 
 ## Other types of resources
 

--- a/_posts/2017-04-19-sge-job-validation-2.md
+++ b/_posts/2017-04-19-sge-job-validation-2.md
@@ -10,7 +10,7 @@ description:
 type: text
 ---
 
-In [a previous post](link://slug/sge-job-validation), 
+In [a previous post]({% post_url 2017-03-20-sge-job-validation %}), 
 I noted that if you're not sure if a Sun Grid Engine (SGE) job can ever run on an [HPC cluster](https://en.wikipedia.org/wiki/Supercomputer)
 you can perform 'dry-run' job validation:
 by passing `-w v` as arguments to `qrsh`/`qrshx`/`qsh`/`qalter` you can ask the SGE scheduler software 


### PR DESCRIPTION
These appear to have been left over from the pre-jekyll days