### PR TITLE
September 2020 newletter

### DIFF
--- a/_newsletters/2020-08-01-newsletter.md
+++ b/_newsletters/2020-08-01-newsletter.md
@@ -1,0 +1,80 @@
+---
+layout: post
+title: September 2020 Newsletter
+editor: John Charlton
+slug: 2020-09-01-newsletter
+date: 2020-09-01 12:00:00 UTC
+tags: 
+category:
+link:
+description:
+type: text
+---
+
+## University of Sheffield Research Software Engineering Team Newsletter September 2020
+
+This is the 3rd monthly newsletter from the Research Software Engineering Team at Sheffield. We aim to share our experiences and information of other communities for those using software for research.
+This newsletter is a collection of interesting events and opportunities over the coming month. It also includes signposting to other resources that we have found beneficial or interesting.
+You may find the content within interest if you are a Research Technology Professional: someone in research using software, such as researchers, research developers, or people paid to develop software like Research Software Engineers (RSEs).
+
+To receive this newsletter as an email each month, please sign up to our [Google Group](https://groups.google.com/a/sheffield.ac.uk/forum/#!forum/rse-group).
+
+*All dates and times are in BST (UTC+01)*
+
+### Events
+
+* [LunchBytes: Writing safer Python code](https://rse.shef.ac.uk/events/lunchbytes-2020-09-09.html) -  9th September 2020 12:00-13:00 *(More details below)*
+* [Woman + DCS: Frontiers of Search](https://sites.google.com/sheffield.ac.uk/womendcs/upcoming-seminars) talks about the technical problems of using search processing for common applications such as private documents and non-english languages. 9th September 2020 14:00
+* [Gaussian Process Summer School](http://gpss.cc/gpss20/): Learn about Gaussian Processes with experts from the University of Sheffield and beyond - September 14th 2020 to September 17th 2020
+* [The Series of Online Research Software Events (SORSE)](https://sorse.github.io/programme/) is kicking off a variety of presentations in September. More talks are being added so check the programme for up to date details of specific talks. The Programme starts from 14:00 2nd September. Some interesting talks for this month include:
+	* [I Wanna Dance With Somebody](https://sorse.github.io/programme/talks/event-001/) - 14:10 2nd September 
+	* [UXF - Framework for creating Virtual Reality human behavior experiments in Unity](https://sorse.github.io/programme/talks/event-012/) - 20:00 22nd September 
+	* [Towards Knowledge Graphs of Research Software metadata](https://sorse.github.io/programme/talks/event-010/) - 20:30 22nd September
+* [The Annual General Meeting of the Society of Research Software Engineering](https://society-rse.org/events/agm-2020/) - 14:00 7th September 
+
+
+#### Lunchbytes
+
+A new monthly series of short talks on research computing, data workflows, and infrastructure.  The first session is to be on 12:00-13:00 9th September 2020 and is themed around *writing safer Python code*:
+
+ - Type Annotations - how to reduce the risk of passing the wrong type of argument to functions (Joe Heffer, IT Services)
+ - Automatable testing of code using pytest (David Jones, RSE team)
+ - Writing safer functions that are easier to reason about (Will Furnass, RSE team)
+
+Each talk will be ~10 minutes, leaving half an hour for discussion/questions.
+
+You'll notice that all presenters are from IT Services or the RSE team; in future we hope that people from the research community feel able to either *request* LunchBytes talks from others or *offer* LunchBytes talks on topics they find interesting.  We'll tell you more about the mechanisms for making requests / offering talks at the first meetup!
+
+Sign up to our [mailing list](https://groups.google.com/a/sheffield.ac.uk/forum/#!forum/rse-group) to be notified of Blackboard Collaborate joining instructions!
+
+The following Lunchbytes is scheduled for October. It will be lead by our own David Wilby. The topic is regarding: "Notebooks - good or evil". We invite people with experience and thoughts in this topic to give a talk. Please get in contact to find out more.
+
+### Opportunities
+
+* Last chance at the EPSRC [Call for Access to High Performance Computing (HPC)](https://epsrc.ukri.org/funding/calls/access-to-high-performance-computing/) - 4th September deadline.
+* A new initiative [SORSE](https://sorse.github.io/) was launched in July, with the intent to deliver weekly online content for RSEs to develop skills and collaborate. Abstracts for proposed events can be submitted [here](https://sorse.github.io/programme/call-for-contributions/). Deadline for talk submission is 1st September.
+* [UKRI Coronavirus Hub](https://www.ukri.org/research/coronavirus/) - Collaborations between RSEs and academics can be very productive ways of developing epidemiological models.
+* [Innovation Scholars: Data Science Training in Health & Bioscience](https://esrc.ukri.org/funding/funding-opportunities/innovation-scholars-data-science-training-in-health-bioscience/) - 30th September
+* [EPSRC Doctoral Prize Fellowship 2020](https://www.sheffield.ac.uk/rs/scholarships/calls) - 22nd October
+* [N8 CIR RSE Theme Lead Job](https://n8cir.org.uk/news/n8-cir-are-recruiting/) - 11th September
+
+
+### Web and Blogs
+* Pauls Richmond has made a society trustee report (link?)
+* Twin has done something with TPUs.
+* [Mike Croucher compares the performance to cost of Amazon HPC processor architectures](https://www.nag.com/blog/sunny-weather-forecast-arms-cost-solution-cloud-hpc)
+
+### Training Resources
+
+* IT Services: Research provides [training in a range of research software related areas](https://www.sheffield.ac.uk/it-services/research/training).
+* The Library’s Scholarly Communications Team provides [training and support for data management planning](https://www.sheffield.ac.uk/library/rdm/training).
+* Keen to learn R from the comfort of your home? [Online R training](https://sbc.shef.ac.uk/training/r-introduction-online/) from the Sheffield Bioinformatics Core may be the answer!
+* Twin Karmakharm from the RSE team has put together a [list of online training resources](https://rse.shef.ac.uk/training/programming), mainly around **Python** and **git**.
+
+If you think there are other great training resources we should advertise, please get in [contact](rse-team-group@sheffield.ac.uk).
+
+### Sheffield RSE Team Services
+
+The RSE team aims to collaborate with you to help improve your research software. We can provide dedicated staff to ensure that you can deliver excellent research software engineering on your research projects.
+
+The RSE team provides free [Code clinics](https://rse.shef.ac.uk/support/code-clinic/) and [paid services](https://rse.shef.ac.uk/service/) allowing us to collaborate longer term.

--- a/_newsletters/2020-08-01-newsletter.md
+++ b/_newsletters/2020-08-01-newsletter.md
@@ -15,7 +15,7 @@ type: text
 
 This is the 3rd monthly newsletter from the Research Software Engineering Team at Sheffield. We aim to share our experiences and information of other communities for those using software for research.
 This newsletter is a collection of interesting events and opportunities over the coming month. It also includes signposting to other resources that we have found beneficial or interesting.
-You may find the content within interest if you are a Research Technology Professional: someone in research using software, such as researchers, research developers, or people paid to develop software like Research Software Engineers (RSEs).
+You may find the content within interest if you are someone in research using software: such as researchers, research developers, or people paid to develop software like Research Software Engineers (RSEs).
 
 To receive this newsletter as an email each month, please sign up to our [Google Group](https://groups.google.com/a/sheffield.ac.uk/forum/#!forum/rse-group).
 
@@ -30,7 +30,7 @@ To receive this newsletter as an email each month, please sign up to our [Google
 	* [I Wanna Dance With Somebody](https://sorse.github.io/programme/talks/event-001/) - 14:10 2nd September 
 	* [UXF - Framework for creating Virtual Reality human behavior experiments in Unity](https://sorse.github.io/programme/talks/event-012/) - 20:00 22nd September 
 	* [Towards Knowledge Graphs of Research Software metadata](https://sorse.github.io/programme/talks/event-010/) - 20:30 22nd September
-* [The Annual General Meeting of the Society of Research Software Engineering](https://society-rse.org/events/agm-2020/) - 14:00 7th September 
+* [The Annual General Meeting of the Society of Research Software Engineering](https://society-rse.org/events/agm-2020/). Learn about what the society has been up to, as well as their aims and directions, and join in the trustee elections - 14:00 7th September 
 
 
 #### Lunchbytes
@@ -57,12 +57,12 @@ The following Lunchbytes is scheduled for October. It will be lead by our own Da
 * [Innovation Scholars: Data Science Training in Health & Bioscience](https://esrc.ukri.org/funding/funding-opportunities/innovation-scholars-data-science-training-in-health-bioscience/) - 30th September
 * [EPSRC Doctoral Prize Fellowship 2020](https://www.sheffield.ac.uk/rs/scholarships/calls) - 22nd October
 * [N8 CIR RSE Theme Lead Job](https://n8cir.org.uk/news/n8-cir-are-recruiting/) - 11th September
-
+* [The CIUK Cluster Challenge](https://www.scd.stfc.ac.uk/Pages/CIUK2020.aspx). Undergraduate and graduate students participate in numerous mini challenges leading up to the CIUK conference. Winners secure a place at the ISC Cluster Challenge in Germany next year-30th September
+* [NVIDIA Graduate Fellowship Awards](https://www.nvidia.com/en-us/research/graduate-fellowships/). For students in GPU-based research who have completed the 1st year of Ph.D. - 11th September
 
 ### Web and Blogs
-* Pauls Richmond has made a society trustee report (link?)
-* Twin has done something with TPUs.
-* [Mike Croucher compares the performance to cost of Amazon HPC processor architectures](https://www.nag.com/blog/sunny-weather-forecast-arms-cost-solution-cloud-hpc)
+* Pauls Richmond has been preparing for the RSE Society AGM with a [trustee report](http://bit.ly/socrse-report-2020)
+* Mike Croucher compares the [performance to cost of Amazon HPC processor architectures](https://www.nag.com/blog/sunny-weather-forecast-arms-cost-solution-cloud-hpc)
 
 ### Training Resources
 
@@ -70,6 +70,13 @@ The following Lunchbytes is scheduled for October. It will be lead by our own Da
 * The Library’s Scholarly Communications Team provides [training and support for data management planning](https://www.sheffield.ac.uk/library/rdm/training).
 * Keen to learn R from the comfort of your home? [Online R training](https://sbc.shef.ac.uk/training/r-introduction-online/) from the Sheffield Bioinformatics Core may be the answer!
 * Twin Karmakharm from the RSE team has put together a [list of online training resources](https://rse.shef.ac.uk/training/programming), mainly around **Python** and **git**.
+* Staff and Students at the University of Sheffield have free access to [FutureLearn if they register by October](https://www.futurelearn.com/campus/the-university-of-sheffield). Futurelearn contains a collection short online courses. Of particular usefulness are 5 courses provided by [PRACE](https://prace-ri.eu/):
+	* Defensive Programming and Debugging
+	* Managing Big Data with R and Hadoop
+	* Python in High Performance Computing
+	* Supercomputing
+	* MPI: A Short Introduction to One-sided Communication
+
 
 If you think there are other great training resources we should advertise, please get in [contact](rse-team-group@sheffield.ac.uk).
 


### PR DESCRIPTION
Things changed;
- Added timezone info at end of introduction
- October Lunchbytes talk

Things that might not be needed:
- RSE AGM. Not sure if this newletter is the right audience for this event
- October Lunchbytes. I'm not sure of the talk title. I included a call for talks, but is this necessary?

Things still to do:
- PR published a society trustee report. Not sure of the details
- TC did something with TPUs. Not sure of the details
