### PR TITLE
Show events on the home page based on  date rather than datetime

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ description: > # this means to ignore newlines until "baseurl:"
   seeking help with research software and as a community for research software engineers.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://rse.shef.ac.uk" # the base hostname & protocol for your site, e.g. http://example.com
+# timezone for the build server, set to london to make event dates probably fine.
+timezone: Europe/London
 twitter_username: rse_sheffield
 github_username: RSE-Sheffield
 twitter:

--- a/_includes/events_list_upcoming.html
+++ b/_includes/events_list_upcoming.html
@@ -1,4 +1,4 @@
-{% assign current_date = site.time | date: '%s' %}
+{% assign current_date = site.time | date: '%F' | date: '%s' %}
 {% assign events = site.events | sort: "date" %}
 <div class="event-listing event-upcoming">
 {% for evt in events %}


### PR DESCRIPTION
This allows events to show up on the day of the event  (if a build has occured on that day) 

It does not account for multi-day events which don't seem to be something we have reliable data for (or any examples?) or check time on the day.

Sets the build timezone to europe/london, which will probably behave how we expect it to.

closes #435

There is JS in place to remove events which are in the past from being rendered at runtime already.