### PR TITLE
Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
+   gem "jekyll-paginate"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Blog posts are located in the `_posts` directory.
 
 The filename **MUST** be prepended with a date (ISO 8601) e.g. `2018-01-01-foo-bar.md`.
 
-Each blog post has a YAML *FrontMatter*, which **must** contain a `slug` (unique), `title`, `author`, and `date`.
+Each blog post has a YAML *FrontMatter*, which **must** contain a `slug` (unique), `title`, `author`, `date` and `excerpt_separator`.
 Optional fields can also be included, such as `layout`, `category` (or `categories`), `tags` etc.
 `image` is an optional field and will override the default image (RSE logo) for social cards. 
 
@@ -139,11 +139,14 @@ slug: foo-bar
 title: foo-bar
 author: Baz
 date: 2018-01-01 00:00:00
+excerpt_separator: <!--more-->
 category:
 tags:
 social_image: /assets/images/logo/rse-logoonly-stroke.png
 ---
 ```
+
+The `excerpt_separator` defines a token, which when placed in the blog post causes the remainder of the post to be omitted from blog post previews shown around the website (e.g. [here](https://rse.shef.ac.uk/blog/). It is recommended that blog posts account for the excerpt by having the first paragraph/s act as an introduction to the blog post's content. If `excerpt_separator` is not included in the front-matter, the first line-break will be treated as the end of the excerpt, the suggested seperator `<!--more-->` is a html comment so will not be visible within blog posts.
 
 **Warning: GitHub will refuse to serve Jekyll sites that include funny characters (e.g. `&` or `@` in the `title:` YAML field unless the entire title is enclosed in double-quotes**, even though the Jekyll site will build locally without warnings.
 

--- a/_config.yml
+++ b/_config.yml
@@ -51,14 +51,14 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-redirect-from
+  - jekyll-paginate
 exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
 strict_front_matter: true
 defaults:
-  -
-    scope:
+  - scope:
       path: "pages"
     values:
       layout: "page"
@@ -82,3 +82,7 @@ defaults:
       type: "newsletters"
     values:
       layout: "newsletter"
+
+# Configure Blog
+paginate: 10
+paginate_path: /blog/page:num/

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,16 +21,23 @@ layout: page
 
 {{ content }}
 
-
-<div class="row">
-    <div class="col-6 text-left">
+<!-- Pagination links -->
+<div class="pagination-wrapper">
+    <div class="pagination">
         {% if page.previous.url %}
-        <a class="prev" href="{{page.previous.url}}">&laquo; Previous</a>
+        <a href="{{ page.previous.url }}" class="previous">
+          Previous
+        </a>
+        {% else %}
+        <span class="previous">Previous</span>
+        {% endif %}
+        {% if page.next.url %}
+        <a href="{{ page.next.url }}" class="next">Next</a>
+        {% else %}
+        <span class="next ">Next</span>
         {% endif %}
     </div>
-    <div class="col-6 text-right">
-        {% if page.next.url %}
-        <a class="next" href="{{page.next.url}}">Next &raquo;</a>
-        {% endif %}
+    <div class="all-posts">
+        <a href="/blog/all" class="small">Directory of Posts</a>
     </div>
 </div>

--- a/_posts/2020-01-09-gpu-course.md
+++ b/_posts/2020-01-09-gpu-course.md
@@ -9,11 +9,14 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 The following 12 week course in "Parallel Computing with GPUs" is available to PhD students and research staff (including academic staff).
 
 Course Details: [https://paulrichmond.shef.ac.uk/teaching/COM4521/](https://paulrichmond.shef.ac.uk/teaching/COM4521/)
+
+<!--more-->
 
 The module is traditionally taught as a 4th year undergraduate and masters course but is typically has a high update of research students and staff who are wanting to learn about shared memory parallel and GPU computing.
 

--- a/_posts/2020-01-22-love-data-week.md
+++ b/_posts/2020-01-22-love-data-week.md
@@ -9,12 +9,15 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 [Love Data Week](https://lovedataweek.org/about-ldw/) is an annual global event designed to 
 **raise awareness** and **build a community** to engage on topics related to **research data management**, **sharing**, **preservation**, **reuse**, and **library-based research data services**. 
 
 The [University of Sheffield's Library](https://www.sheffield.ac.uk/library) have organised several events for this year's Love Data Week (10-14 February 2020):
+
+<!--more-->
 
   * 11th Feb, 10:00 - 12:00: DDP workshop on *Looking after your Research Data*. 
     NB now **fully booked** but 

--- a/_posts/2020-02-04-vacancies.md
+++ b/_posts/2020-02-04-vacancies.md
@@ -9,12 +9,15 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 We're looking for two people to join our team: 
 
 * A Research Software Engineer to work on complex systems modelling accelerated using GPUs;
 * A Community Engagement and Training Officer 
+
+<!--more-->
 
 ## Research Software Engineer (Complex Systems Simulation using GPUs)
 

--- a/_posts/2020-02-28-hpc-sig-champions.md
+++ b/_posts/2020-02-28-hpc-sig-champions.md
@@ -9,11 +9,13 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 I've just come back from [HPC Special Interest Group (HPC-SIG)][hpc-sig] and [HPC Champions][hpc-champions] (formerly ARCHER Champions) events on the 
 25th and 26th of Feb in Bath, so thought I'd do a write-up. There's updates on Liverpool and Bath's cloud HPC, ARCHER 2, Tier-2 HPC refresh and how you can get extra GPU compute for your research!
 
+<!--more-->
  
 ## Liverpool and Bath's Journey to the Clouds
 Cliff Addison (Liverpool) and Steven Chapman (Bath) gave talks on their respective university's integration of cloud infrastructure 

--- a/_posts/2020-03-17-code-clinics-online.md
+++ b/_posts/2020-03-17-code-clinics-online.md
@@ -9,11 +9,14 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 In response to the need for increased remote working as a result of the current Covid-19 situation, we're going to be doing our [Code Clinics](/support/code-clinic) remotely using Google Hangouts for now.
 
 Code Clinics remain a great way to get help with writing and maintaining code and with reduced physical access to labs, perhaps now is good time to focus on this aspect of research. **We can offer advice on working with and executing code remotely.**
+
+<!--more-->
 
 We'll do our best to help with:
 

--- a/_posts/2020-03-24-configuring-cuda-and-opengl-courses-in-the-cloud.md
+++ b/_posts/2020-03-24-configuring-cuda-and-opengl-courses-in-the-cloud.md
@@ -9,11 +9,14 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 Academics and RSEs have been very busy over the last few weeks coming up with creative solutions to move teaching and training online. My own under/post graduate GPU module [Parallel Computing with GPUs](https://paulrichmond.shef.ac.uk/teaching/COM4521/) has posed a significant problem. The course was designed to be run within the University of Sheffield's High Specification teaching lab which is equipped with CUDA enabled GPUs. Moving this course online clearly requires a mechanism for students to access GPUs, without presenting a significant change to their current working practice (e.g. Visual Studio development in Windows). Ideally this cold be done using the [university's high performance computing facilities](https://www.sheffield.ac.uk/it-services/research/hpc) but the provision for GPUs is currently insufficient to support 100 students (although new GPUs are on the way). The obvious solution is to move this to the cloud however there are a number of challenges to solve which are the topic of this blog post which also serves as a reference for when I forget all of this in 6 months time.
 
 *Note: This blog specifically targets AWS as it is what I have used on the [InstanceHub](https://www.instancehub.com) website which is part of the solution to Problem 3.*
+
+<!--more-->
 
 ## Problem 1: GPU Accelerated Instances with Graphical Displays
 

--- a/_posts/2020-03-29-git-github-remote.md
+++ b/_posts/2020-03-29-git-github-remote.md
@@ -9,9 +9,12 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 As software engineers, we were lucky to have a running start at shifting to remote working practices as part of our institutional response to COVID-19. We have very little physical infrastructure in the team and can access most of what we need to do through the internet, even each other through video calls, emails and text chat. We can rely on our I.T. Services to provide a virtual network (VPN) and virtual machines for hosted applications. However, there is one area where I feel like we've made our own luck - collaborating on developing software. A big part of our ethos is to identify good practices, put them into action and share them with others. So I'm going to talk a bit here about how we use [git](https://git-scm.com/) and [GitHub](https://github.com/) not just to track changes and contributions to code, but to manage projects. And, as it turns out, this is actually pretty easy if you have a little time to invest. The difficulty, for many of us, is finding that time, but that's kind of another story!
+
+<!--more-->
 
 ## **git** and **GitHub** - what's the difference?
 

--- a/_posts/2020-04-06-announce-gpu-hackathon-2020.md
+++ b/_posts/2020-04-06-announce-gpu-hackathon-2020.md
@@ -9,6 +9,7 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 Following the success of our 2019 event,
@@ -17,6 +18,8 @@ as part of the NVIDIA international GPU Hackathon Series.
 
 This event will take place between **27 – 31 July 2020**,
 most likely as an online event unless government restrictions around COVID-19 are significantly altered.
+
+<!--more-->
 
 Prior GPU experience is not required,
 as those selected will be paired with experienced mentors who will teach them how to

--- a/_posts/2020-05-20-ssh-best-prac.md
+++ b/_posts/2020-05-20-ssh-best-prac.md
@@ -9,6 +9,7 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 *Including High-Performance Computing clusters*
@@ -27,6 +28,8 @@ to consider these, even if the remote machines are not managed by the
 University of Sheffield as poorly managed keys/passwords could allow
 others to impersonate you, which could result in further cyberattacks,
 data theft/loss and reputational damage to you and the University.
+
+<!--more-->
 
 If you **typically use a password to authenticate via SSH** then consider what
 damage could be done should someone else acquire/guess your password.  This is

--- a/_posts/2020-09-03-agile.md
+++ b/_posts/2020-09-03-agile.md
@@ -16,6 +16,8 @@ I formally led a software development team for the first time as part of the [Sc
 
 This post is about management and leadership on the project.
 
+<!--more-->
+
 ## Our software
 
 Simple Network Sim models a covid-19 pandemic by breaking a population down into nodes (representing specific geographic areas) in a network. Each node has numbers of people in various states (e.g. exposed, infected, recovered, dead) and the model is parameterised with rates of transition between these states. This is modified by levels of mixing between people of different age groups. People also move between the geographic nodes so changes in movement patterns can be simulated. This means it's possible to simulate things like:

--- a/_posts/2020-09-22-slt-cdt-hpc-pres.md
+++ b/_posts/2020-09-22-slt-cdt-hpc-pres.md
@@ -10,6 +10,7 @@ link:
 description:
 type: text
 social_image: /assets/images/cluster-diag-plain.svg
+excerpt_separator: <!--more-->
 ---
 
 Two challenges PhD students encounter are: 
@@ -19,6 +20,8 @@ Two challenges PhD students encounter are:
 To help address the above for a particular case I spoke with a new cohort of PhD students today (from the [Speech and Language Technologies Centre for Doctoral Training](https://slt-cdt.ac.uk/))
 to explain what high-performance computing (HPC) is and why they might care.
 The hope is that they will now be able to include HPC in their training plans once they recognise problems that HPC might be well-suited to helping with.
+
+<!--more-->
 
 The talk covered:
  - Pros and cons of HPC vs personal laptops/desktops

--- a/_posts/2020-12-07-reproducibility-resources.md
+++ b/_posts/2020-12-07-reproducibility-resources.md
@@ -9,11 +9,17 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
+
+This blog post provides a copy of my recent talk at the Royal Microscopical Society's [Virtual Data Analysis in Atomic Force Microscopy Meeting](https://www.rms.org.uk/data-analysis-in-atomic-force-microscopy.html) ([Event Page](/events/talk-2020-12-10-afmanalysis)): How can we make AFM data analysis more open and reproducible?
+
+I've also put together what I hope will be some useful links:
+
+<!--more-->
 
 <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vTiYzbk9AzBz9DtZwEtD_ObfMiN7fZfrMNbLzRdypcolrekuAobZZxGdtoto6xUpsVxLVkpvWV1uGNk/embed?start=false&loop=false&delayms=60000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 
-To go along with my talk at the Royal Microscopical Society's [Virtual Data Analysis in Atomic Force Microscopy Meeting](https://www.rms.org.uk/data-analysis-in-atomic-force-microscopy.html) ([Event Page](/events/talk-2020-12-10-afmanalysis)), I've put together what I hope will be some useful links:
 
 ## If you’re a researcher at the University of Sheffield...
 

--- a/_posts/2021-01-25-datavis-cpp.md
+++ b/_posts/2021-01-25-datavis-cpp.md
@@ -10,6 +10,7 @@ link:
 description:
 social_image: /assets/images/2021-01-25-datavis-cpp/image1.png
 type: text
+excerpt_separator: <!--more-->
 ---
 
 *A guest post by [Seb James](https://www.sheffield.ac.uk/psychology/people/research/sebastian-james-0), Research Associate, Department of Psychology ([GitHub](https://github.com/sebjameswml); [Twitter](https://twitter.com/sebjames)).*
@@ -17,6 +18,8 @@ type: text
 ---
 
 In this blog post I'm going to talk about data visualisation - making graphs - within C++ programs. I'll describe why you might want to do this and I'll try to justify why I've spent a sizeable part of my time over the last couple of years developing graphing code in C++, rather than using Python or R like everyone else! The code I'll discuss is available at [https://github.com/ABRG-Models/morphologica](https://github.com/ABRG-Models/morphologica).
+
+<!--more-->
 
 {% include image_caption.html url="/assets/images/2021-01-25-datavis-cpp/image0.png" description="A selection of visualisations made with morphologica. A: 2D graphs. B A: self-organising map simulation (orientation preference maps). C: Three dimensional quiver plot. D: gene driven reaction diffusion model. E: Debugging a large model."%}
 

--- a/_posts/2021-01-25-secondment-opportunity.md
+++ b/_posts/2021-01-25-secondment-opportunity.md
@@ -9,11 +9,14 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 Are you currently working or studying at the University of Sheffield and interested in a secondment to the Research Software Engineering (RSE) team to develop sustainable research software?
 
 The RSE team has grown in the last couple of years but there is currently unprecedented demand for RSE support on research projects.  We are urgently looking for someone to join our team of twelve on a short to medium term basis to work on one or two specific projects, the most significant being a role in the Scottish Covid Response Consortium ([https://scottishcovidresponse.github.io](https://scottishcovidresponse.github.io)). The main activities in that project include improving some modelling software, developing a data pipeline and an API, and integrating the modelling software within a framework.  **Python** development experience, a working knowledge of version control with **git**/**GitHub** and of **software testing** are key; experience of developing/using **web services** and **databases** would also be useful.  We want this secondment to be an opportunity for growth and we will support and mentor you in this role.
+
+<!--more-->
 
 This would be a great opportunity for someone who is considering a career in research software (or infrastructure/data) engineering and is wanting first-hand experience of how it might compare to a traditional research career. This placement would be suitable for staff already employed elsewhere within the university either on a research contract or on core funding (subject to agreement with your line manager). Similarly the post would be suitable for a PhD student in their final year looking for part time employment.
 

--- a/_posts/2021-02-04-GPU-course.md
+++ b/_posts/2021-02-04-GPU-course.md
@@ -9,9 +9,12 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 Starting Monday 7th Feb is a 12 week course on *Parallel Computing with GPUs*. The course has been designed as an undergraduate 4th year module for Computer Science but is available to staff and PhD Students (as part of the DDP program) and regularly has staff and PhD student enrollment. 
+
+<!--more-->
 
 The first 3 weeks are focused on teaching C and OpenMP followed by GPU programming with CUDA C. Lectures are provided as pre-recorded mini lectures and there are 2 hours of scheduled support per week to undertake practical lab classes. Assessment is not required for DDP or staff participants. Virtual Remote machines will be provided with dedicated GPUs.
 

--- a/_posts/2021-04-14-hidden-ref.md
+++ b/_posts/2021-04-14-hidden-ref.md
@@ -9,12 +9,15 @@ category:
 link:
 description:
 type: text
+excerpt_separator: <!--more-->
 ---
 
 The Research Excellence Framework (REF) is the UK government's scheme for assessing the quality of research in UK universities. Every few years, UK universities are asked to submit examples of their research for review, following an internal review process. In short, universities submit their best examples of:
   * published articles,
   * case studies of research impact, and
   * data on doctoral degrees awarded and research income.
+
+<!--more-->
 
 Ultimately, the outcome of the REF dictates central government funding provided to Universities - which, as a result, are incentivised to place value predominantly on research activities and outputs which result in high quality rankings in the REF. (See an explanation of these competing demands here: https://hidden-ref.org/about/)
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -11,6 +11,13 @@
     lg @media (min-width:992px)
     xl @media (min-width:1200px)
 */
+/* Sizes for h1 to h6, overriding bootstrap css */
+h1, .h1 { font-size: 2.5rem; }
+h2, .h2 { font-size: 2rem; }
+h3, .h3 { font-size: 1.75rem; }
+h4, .h4 { font-size: 1.5rem; }
+h5, .h5 { font-size: 1.25rem; }
+h6, .h6 { font-size: 1rem; }
 
 .nav-link{
     color: #1c3248 !important;
@@ -52,6 +59,50 @@ figcaption {
     font-size: small;
 }
 
+/* Style Pagination of Blogposts */
+.pagination a, .pagination span {
+    padding: 7px 18px;
+    border: 1px solid #eee;
+    margin-left: -2px;
+    margin-right: -2px;
+    margin-bottom: 0px;
+    background-color: #ffffff;
+    display: inline-block;
+}
+.pagination a:hover {
+    background-color: #f1f1f1;
+    text-decoration: none;
+}
+.pagination a {
+    cursor: pointer;
+}
+.pagination {
+    text-align: center;
+}
+/* Adjust heading sizes for blog-excerpts */
+.blog-excerpt h1, .blog-excerpt .h1 { font-size: 2rem; }
+.blog-excerpt h2, .blog-excerpt .h2 { font-size: 1.75rem; }
+.blog-excerpt h3, .blog-excerpt .h3 { font-size: 1.5rem; }
+.blog-excerpt h4, .blog-excerpt .h4 { font-size: 1.25rem; }
+.blog-excerpt h5, .blog-excerpt .h5 { font-size: 1rem; }
+.blog-excerpt h6, .blog-excerpt .h6 { font-size: 1rem; } /* No h7 to steal a size from */
+
+ hr.blog-post-seperator {
+  width: 50%; /*Differentiate hr, to those used within markdown/blog posts*/
+  border-top: 2px solid;
+  margin-top: 32px; /*2 rem, double end of paragraph*/
+  margin-bottom: 32px;
+}
+div.pagination-wrapper {
+  justify-content: center;
+  flex-flow:row wrap;
+  display: flex;
+}
+div.all-posts {
+  flex-basis: 100%;
+  text-align: center;
+  margin-bottom: 16px; /*1 rem, same as end of paragraph*/
+}
 
 /* Extra custom styling for pre / code blocks */
 pre {

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,56 @@
+---
+layout: page
+title: RSE Sheffield Blog
+---
+
+<!-- This loops through the paginated posts -->
+{% for post in paginator.posts %}
+
+  <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+{% if post.author %}
+<div class="media mb-1">
+    <img class="align-self-center mr-2" src="/assets/images/icons/icons8-person-50.png" width="20"/>
+    <div class="media-body"><strong>{{ post.author }}</strong></div>
+</div>
+{% endif %}
+
+{% if post.date %}
+<div class="media mb-1">
+    <img class="align-self-center mr-2" src="/assets/images/icons/icons8-watch-50.png" width="20"/>
+    <div class="media-body"><strong>{{ post.date | date: "%-d %B %Y %H:%M" }}</strong></div>
+</div>
+{% endif %}
+
+<div class="blog-excerpt">
+    {{ post.excerpt }}
+</div>
+
+  {% if post != paginator.posts.last %}
+<hr class="blog-post-seperator"/>
+  {% endif %}
+
+{% endfor %}
+
+<!-- Pagination links -->
+<div class="pagination-wrapper">
+<div class="pagination">
+  {% if paginator.previous_page %}
+    <a href="{{ paginator.previous_page_path }}" class="previous">
+      Previous
+    </a>
+  {% else %}
+    <span class="previous">Previous</span>
+  {% endif %}
+  <span class="page_number ">
+    Page: {{ paginator.page }} of {{ paginator.total_pages }}
+  </span>
+  {% if paginator.next_page %}
+    <a href="{{ paginator.next_page_path }}" class="next">Next</a>
+  {% else %}
+    <span class="next ">Next</span>
+  {% endif %}
+</div>
+<div class="all-posts">
+<a href="/blog/all" class="small">Directory of Posts</a>
+</div>
+</div>

--- a/pages/blog/all.md
+++ b/pages/blog/all.md
@@ -1,7 +1,7 @@
 ---
 title: Blog
 layout: page
-permalink: /blog/
+permalink: /blog/all
 ---
 
 <br/>


### PR DESCRIPTION
I recovered some/all the changes from #154 for pagination.

It appears I'm missing the commit which added manual separator to all old blogposts (I presumably never pulled that update to my laptop before overwriting remote, it will exist on my desktop in Sheffield but I don't currently have access to that).

Demo here: https://rse-mirror.robadob.org/blog/

From the previous PR:

> To manage this, you need to additionally include `excerpt_separator: <!--more-->` in the front matter, and then place your separator (e.g. `<!--more-->`) somewhere in the body of your post. Everything above that separator will appear above the fold. If this isn't included, it appears to simply treat the first blank line as the separator.