### PR TITLE
Add form for proposing things to be included in RSE newsletter.

### DIFF
--- a/pages/newsletters.md
+++ b/pages/newsletters.md
@@ -4,4 +4,17 @@ layout: page
 permalink: /newsletters/
 ---
 
+The University of Sheffield Research Software Engineering team curates a monthly newsletter of 
+information, activities and events related to research software/computing.  
+It typically features information and links to: 
+news, interesting blog posts, future events, recent events, job/volunteer opportunities and tutorials.
+
+Let us know if you'd like something to be included in the newsletter by:
+
+* completing [this short form](https://forms.gle/YyQiNjg79tXaLZHq8) (University of Sheffield staff and students) *or* 
+* by emailing `rse@sheffield.ac.uk` (for people outside the University)
+
+We can't promise that we'll publish everything that's proposed but 
+we are keen to feature submissions from the research community at the University of Sheffield.
+
 {% include newsletters_list.html %}


### PR DESCRIPTION
@robadob has noticed that our free Slack workspace is now sufficiently busy that messages now start falling off the end of the buffer after ~35d, so we'll soon need a mechanism other than a Slack channel for capturing submissions for the next newsletter.

This PR proposes using a Google Form for capturing that info. This might result in duplicate submissions but that's unlikely to be a major issue (and even if it is we could make the associated Google Sheet read-only to all at TUOS so people could review previous submissions.

A Google Sheet would also allow us to tag submissions as being best suited to publication in newsletters other than the upcoming one and possibly maintain a list of things that could be used to flesh out the newsletter in quieter months.

If we're happy with this approach I also need to:
 - [x] add info to the newsletter curator's guide
 - [ ] add info to the next newsletter (PR #443; cc @bobturneruk) 