### PR TITLE
Project page improvements

### DIFF
--- a/_data/projects.csv
+++ b/_data/projects.csv
@@ -29,7 +29,7 @@ id,key,title,long_title,tech_methods,rses,start,end,department,level,show
 53,ramp,RAMP SCRC Covid Support,RAMP SCRC Covid Support,"Python, agile, testing, continuous integration, documentation",Robert Turner,01/05/2020,01/08/2020,Computer Science,2,1
 55,,IFPRI,IFPRI,,David Wilby,01/07/2020,01/08/2020,Computer Science,2,1
 56,,Opening Up Minds,Opening Up Minds,,Anna Krystalli,18/01/2021,18/06/2021,Psychology,2,1
-57,floodfotm,Flood Modelling Festival of the Mind,Flood Modelling Festival of the Mind,"GPU, unreal engine, FLAMEGPU","Matt Leach, Paul Richmond",01/07/2020,01/09/2020,Civil Engineering,2,1
+57,floodfotm,Flood Modelling Festival of the Mind,Flood Modelling Festival of the Mind,"GPU, unreal engine, FLAME GPU","Matt Leach, Paul Richmond",01/07/2020,01/09/2020,Civil Engineering,2,1
 58,ratesetter,RateSetter / Merseyrail,RateSetter / Merseyrail,"C++, FLAME GPU, ABM",Twin Karmakharm,18/11/2019,01/12/2020,Mechanical Engineering,2,1
 64,scrc-pipeline,SCRC Follow on,Covid epidemiology data pipeline,"Python, agile, testing, continuous integration, documentation",Robert Turner,01/01/2021,01/01/2022,External,1,1
 65,holeintheroad,Hole in the Road,Hole in the Road,"VR, Unity",Matt Leach,24/09/2020,13/10/2020,Computer Science,1,1

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -151,3 +151,8 @@ blockquote {
 .sm-a:hover{
     color: #e2e2e2;
 }
+
+/* project page tag cloud */
+a.tag-link.selected, a.filter-link.selected{
+    font-weight: bold;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -113,5 +113,29 @@ jQuery(document).ready(function($) {
         }
 
     });
+    
+    /* ======= Projects Tag Cloud ======= */
+    $("a.tag-link").on( "click", function(e) {
+        var tag = $(this).attr("href").substring($(this).attr("href").firstIndexOf('#') + 1);
+        $("a.tag-link.selected").removeClass("selected");
+        $("a.filter-link.selected").removeClass("selected");
+        $(this).addClass("selected");
+        $('.project.tag-' + tag).show();
+        $('.project:not(.tag-' + tag + ')').hide();
+    });
+    $("a.filter-link").on( "click", function(e) {
+        $("a.tag-link.selected").removeClass("selected");
+        $("a.filter-link.selected").removeClass("selected");
+        $(this).addClass("selected");
+        if (!$(this).attr("href")) {
+            // Show all
+            $('.project').show();
+        } else {
+            // Show active/completed
+            var tag = $(this).attr("href").substring($(this).attr("href").lastIndexOf('#') + 1);
+            $('.project.' + tag).show();
+            $('.project:not(.' + tag + ')').hide();
+        }
+    });
 
 });

--- a/pages/service/projects/projects.md
+++ b/pages/service/projects/projects.md
@@ -26,9 +26,12 @@ The Research Software Engineering team at Sheffield has worked on projects invol
 {% assign proj_tags = proj.tech_methods | split: ", " %}
 {% assign all_tags = all_tags | concat: proj_tags %}
 {% endfor %}
-{{ all_tags | sort_natural | uniq | join: " &middot; " }}
+{% assign all_tags = all_tags | sort_natural | uniq %}
+{% for tag in all_tags %}<a class="tag-link" href="#{{ tag | replace: " ", "-" | replace: ".", "DOT" | replace: "#", "HASH" | replace: "&", "AND" | replace: "+", "PLUS" }}">{{ tag | replace: " ", "&nbsp;"}}</a>{% if tag != all_tags.last %} &middot; {% endif %}{% endfor %}
 
 Some projects we have worked on (not a comprehensive list):
+
+Filter: <a class="filter-link selected" href="">All</a> &middot; <a class="filter-link" href="#active">Active</a> &middot; <a class="filter-link" href="#completed">Completed</a>
 
 {% assign levels = site.data.projects | where: 'show',1 | group_by: 'level' | sort: 'name' %}
 {% assign project_descriptions = site.project_descriptions %}
@@ -44,7 +47,8 @@ Some projects we have worked on (not a comprehensive list):
         {% else %}
             {% assign current = false %}
         {% endif %}
-        <div class="{% if current %}active{% else %}completed{% endif %}">
+        {% assign proj_tags = project.tech_methods | split: ", " %}
+        <div class="project {% if current %}active{% else %}completed{% endif %}{% for tag in proj_tags %} tag-{{ tag | replace: " ", "-" | replace: ".", "DOT" | replace: "#", "HASH" | replace: "&", "AND" | replace: "+", "PLUS" }}{% endfor %}">
             <b>{{project.long_title}} </b>
             {% if current %}
                 (Active project)
@@ -71,4 +75,13 @@ Some projects we have worked on (not a comprehensive list):
         <hr/>
     {% endfor %}
 </div>
-
+<script>
+window.addEventListener('load', (event) => {
+    if (window.location.hash) {
+        var tag = window.location.hash.slice(1);
+        // Find the matching tag
+        $("a.tag-link[href$='"+tag+"']").trigger("click");
+        $("a.filter-link[href$='"+tag+"']").trigger("click");
+    }
+});
+</script>


### PR DESCRIPTION
Started working on #454, ended up doing alot more than planned.

**TLDR:** Clicking a tag from the tag cloud, or one of the new filter links, adds `#<tag>` to the address, bolds the clicked item, and hides unrelated items from the project list. If the page loads with the same `#<tag>` in `window.location.href` it simulates the user clicking the associated link. Also fix a couple of minor issues with the tag cloud (`&nbsp` and FLAMEGPU dupe).

Current progress visible [on my mirror site](https://rse-mirror.robadob.org/service/projects)

- [x] ~~Add hidden [active projects page](https://rse-mirror.robadob.org/service/projects/active)~~ (This is redundant)
- [x] Make the projects tag cloud clickable to filter projects
- [x] Replace spaces with `&nbsp` inside tag cloud tags. (to fix "static analysis" wrapping)
- [x] Unify `FLAMEGPU` and `FLAME GPU` tags
- [x] Add filter links for active/completed projects
- [x] On page load, auto parse `#tag` from url, to pretend link was clicked
- [ ] Can the delay on making the clicked tag bold be improved?? (or hidden as a lazy hack with `:hover`)


*Potential issues:*
* Encoding tags to valid css classes via liquid is awkward. I currently escape `.&#+` (and spaces), but there are probably others that will break stuff. I did try the spec documented use of `\` but that didn't seem to work with jquery selectors.
* If `active` or `completed` are added as technical tags, they will clash with the filter links, causing some undefined behaviour.

Closes #454