### PR TITLE
Fix/improve GitHub Actions workflow and adjust readme

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,39 +1,54 @@
 name: CI build 
 on:
-  # push:
-  #   branches:
-  #     - master
+  push:
+    branches:
+      - "*"
   pull_request:
     branches:
       - master
 jobs:
-  checklinks:
+  build:
     name: Linux
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+    env:
+      # Control the use of htmlproofer. Set to '1' to enable htmlproofer.
+      USE_HTMLPROOFER: '0'
     steps:
+      # Clone the repository and checkout into the relevant branch
       - uses: actions/checkout@v2
-      - name: Ruby
-        uses: actions/setup-ruby@v1
+
+      # Install Ruby
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
-      - name: Setup Rubygems, Bundler, jekyll
-        run: | 
+          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+
+      # Install dependencies required to run jekyll build
+      - name: Install gh-pages rubygem via bundler
+        run: |
+          # Update gem and bundler
           gem update --system --no-document
           gem update bundler --no-document
-          gem install jekyll bundler
+          # Set the bundle directory
           bundle config set path vendor/bundle
+          # Install Gemfile contents via bundler
           bundle install
+
+      # Build the website via jekyll
       - name: Build jekyll website with drafts
         run: bundle exec jekyll build --drafts
-      # - name: Check for broken links
-      #   run: |
-      #     bundle exec htmlproofer --disable-external --allow-hash-href --internal-domains=rse.shef.ac.uk,rse.sheffield.ac.uk --log-level :debug ./_site &> links.log
-      #   continue-on-error: true
-      # - name: Archive log links
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: links-check.log
-      #     path: links.log
 
+      # Check for broken links if enabled
+      - name: Check for broken links
+        if: ${{ env.USE_HTMLPROOFER == '1' }} 
+        run: |
+          bundle exec htmlproofer --disable-external --allow-hash-href --internal-domains=rse.shef.ac.uk,rse.sheffield.ac.uk --log-level :debug ./_site &> links.log
+        continue-on-error: true
+
+      # Store the list of potentially broken links 
+      - name: Archive log links
+        if: ${{ env.USE_HTMLPROOFER == '1' }} 
+        uses: actions/upload-artifact@v1
+        with:
+          name: links-check.log
+          path: links.log

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the source for the RSE-Sheffield website, built with [J
 
 The website is hosted on GitHub Pages and can be found at [https://rse.shef.ac.uk](https://rse.shef.ac.uk).
 
-All content (excluding logos or where explicitly stated) licensed under the 
+All content (excluding logos or where explicitly stated) licensed under the
 <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1"
    target="_blank"
    rel="license noopener noreferrer"
@@ -26,14 +26,19 @@ license.
 1. Install Ruby
     * On Windows, this installer can be used [https://rubyinstaller.org/](https://rubyinstaller.org/)
     * On Linux, follow the instructions according to your distribution e.g. for Debian/Ubuntu:
+
         ```sh
         sudo apt install ruby-full
         ```
+
 2. Install `bundler` (via a terminal):
+
    ```sh
-   gem install bundler jekyll
+   gem install bundler
    ```
+
 3. Install other dependencies:
+
     ```sh
     cd path/to/clone/of/this/repo
     bundle config set path vendor/bundle
@@ -75,19 +80,17 @@ bundle exec jekyll build
 
 Generated HTML files can be found in `_site`.
 
-
-
 ## Writing Content
 
 Content can be written in Markdown, reStructuredText or as HTML.
 
-### Assets: Images, PDFs etc.
+### Assets: Images, PDFs etc
 
 Resources such as images should be stored in the `assets` directory. E.g. `assets/images/image.png`.
 
 This can then be included in your markdown file via:
 
-```
+```markdown
 ![description of image](/assets/images/image.png){: .img-fluid}
 ```
 
@@ -98,11 +101,12 @@ This applies the `img-fluid` css class to the generate `<img>` element, to make 
 PDFs or other very large binary files should be stored in an alternate repository, to avoid polluting the main website source with very large files.
 
 ##### Seminar-slides
+
 For seminar content, use the [RSE-Sheffield/seminar-slides](https://github.com/RSE-Sheffield/seminar-slides) repository. Detailed instructions are provided in the README.md for how to add files, and how to link to them.
 
 ##### Others
-Other files could be stored in an appropriate directory within `assets`, or alternatively another repository could be set up similar to [RSE-Sheffield/seminar-slides](https://github.com/RSE-Sheffield/seminar-slides).
 
+Other files could be stored in an appropriate directory within `assets`, or alternatively another repository could be set up similar to [RSE-Sheffield/seminar-slides](https://github.com/RSE-Sheffield/seminar-slides).
 
 ### Linking to Local Content
 
@@ -110,16 +114,13 @@ Ideally link to other pages using either Jekyll's Liquid variables, relative or 
 
 e.g. `[Target]({{site.url}}/target/page/)`, `[Target](target/page/)` or `[Target](/target/page/)`
 
-
 Avoid absolute links such as `https://rse.shef.ac.uk/target/page/` which prevent local testing.
-
-
 
 ### Pages
 
 The general website pages are stored in `pages/`, as Markdown or HTML files.
 
-See the [Jekyll Docs /pages/](for https://jekyllrb.com/docs/pages/) for more information.
+See the [Jekyll Docs /pages/](https://jekyllrb.com/docs/pages/) for more information.
 
 ### Blog Posts
 
@@ -129,11 +130,11 @@ The filename **MUST** be prepended with a date (ISO 8601) e.g. `2018-01-01-foo-b
 
 Each blog post has a YAML *FrontMatter*, which **must** contain a `slug` (unique), `title`, `author`, `date` and `excerpt_separator`.
 Optional fields can also be included, such as `layout`, `category` (or `categories`), `tags` etc.
-`image` is an optional field and will override the default image (RSE logo) for social cards. 
+`image` is an optional field and will override the default image (RSE logo) for social cards.
 
 The YAML header should look something like:
 
-```
+```yaml
 ---
 slug: foo-bar
 title: foo-bar
@@ -160,7 +161,6 @@ Events have a YAML FrontMatter, which **must** include `category`, `date`, `from
 
 The `category` variable classifies the type of event.
 The list of existing categories can be found at `_data/event-categories.yml`.
-
 
 Different categories of event may expect or make use of additional variables, such as `speaker`, `institute` and `title` for the `seminar` category. See other examples of the same category for further details.
 
@@ -190,7 +190,7 @@ Categories should have an associated `image` representation and a `text` value f
 
 i.e.
 
-```
+```yaml
 seminar:
     image: "/assets/images/icons/icons8-training-50.png"
     text: "Seminar"
@@ -204,13 +204,14 @@ To create a new page which lists all events of a given category:
 
 1. Create a new page, i.e. `pages/newcategory.md`
 2. Include the `event_list.html` template with the key from your new category:
-    ```
+
+    ```liquid
     {% include events_list.html category="newcategory" %}
     ```
 
 ### Adding/editing info re RSE team projects
 
-Each project listed in [`_data/projects.csv`](_data/projects.csv) should have a description in a markdown file in the [`_project_descriptions/`](_project_descriptions/) folder. The markdown file nust be named identically to the text in the key column of `projects.csv`. 
+Each project listed in [`_data/projects.csv`](_data/projects.csv) should have a description in a markdown file in the [`_project_descriptions/`](_project_descriptions/) folder. The markdown file must be named identically to the text in the key column of `projects.csv`.
 
 The following project data (and metadata) are to be populated in `projects.csv`:
 
@@ -230,7 +231,7 @@ The following project data (and metadata) are to be populated in `projects.csv`:
 
 Project descriptions are to be written in markdown with a header containing the project key:
 
-```
+```yaml
 ---
 key: <key>
 ---
@@ -238,10 +239,10 @@ key: <key>
 
 The text should address the following:
 
-- A general description of the project, its aims and objectives, link to project website (if available). 
-- What does / did the RSE collaboration add to the project?
-- Current and planned project outputs linked to RSE contribution (e.g. GitHub link, papers, talks).
-- Project impact beyond software (societal benefits, policy change, improved media output, financial / business, public engagement, health benefits).
+* A general description of the project, its aims and objectives, link to project website (if available).
+* What does / did the RSE collaboration add to the project?
+* Current and planned project outputs linked to RSE contribution (e.g. GitHub link, papers, talks).
+* Project impact beyond software (societal benefits, policy change, improved media output, financial / business, public engagement, health benefits).
 
 ## Layout and Style
 
@@ -252,13 +253,11 @@ Layouts (or pages) may reference *includes* which are re-usable sections of mark
 Style should primarily be controlled through CSS, both through the site theme and any custom CSS rules.
 Custom CSS should be specified in `assets/css/custom.css`
 
-
 ### Table Formatting
 
 Markdown tables generated by jekyll are not well-themed by the website theme / bootstrap by default, as classes need adding to the table to improve the formatting. This can be achieved in jekyll using a Kramdown feature as follows:
 
-
-```
+```markdown
 | Example | Table | A |
 |---------|-------|---|
 |       1 |     2 | 3 |


### PR DESCRIPTION
+ GitHub Actions:
  + Uses an activley maintained action to install and enable Ruby on github actions (ruby/setup-ruby)
  + Upates the ruby versions to match the currently deployed github-pages version (2.7.3)
  + Does not manually install the latest jekyll via gem, instead only installing gems via the Gemfile
    + This ensures that a too new jekyll is not used
  + htmlproofer is now enabled / disabled via a workflow env var rather than being commented out
  + CI is now triggered by any push event, as well as the pre-exisitng pull_request event against the master branch.
+ README.md:
  + Installation instructions no longer suggest manually installing the jekyll gem
  + Markdown has been linted, with a number of fixes.
