### PR TITLE
Updating README.md with info on staf page headers; tweaks to my bio

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,46 @@ The general website pages are stored in `pages/`, as Markdown or HTML files.
 
 See the [Jekyll Docs /pages/](https://jekyllrb.com/docs/pages/) for more information.
 
+### Staff Pages
+
+Staff pages contain biographies of current and alumni (previous) members of the team. There are a few key fields that
+require careful attention to when adding a new member or updating details of those who have left the team.
+
+The header of each Markdown file is written in [yaml](https://yaml.org) with intuitive and self-explanatory fields
+names.
+
+
+#### New Members
+
+When adding a new member a new Markdown file should be created under
+`RSE-Sheffield.github.io/_people/<forename>-<surname>.md` with the following example YAML header.
+
+```yaml
+---
+alumnum: false
+level: 2
+published: true
+
+othernames: <forename>
+surname: <surname>
+role: <role>
+---
+```
+
+Most fields required for the header are self-explanatory. One key field is that of `level` which should be completed
+according to the level of appointment as detailed in the table below.
+
+| Level | Description                       |
+|:-----:|:----------------------------------|
+| 0     | Head of Department                |
+| 1     | Senior Research Software Engineer |
+| 2     | Research Software Engineer        |
+| 3     | Junior Research Software Engineer |
+
+Details of alumni of the RSE team are kept and this is defined by the `alumnum` field. Whilst a member of the team this
+should be `false` and their profile will be listed under _Contact > Alumni_, but after having left the team it should
+be `true` which means their details will be listed under _Contact > Alumni_.
+
 ### Blog Posts
 
 Blog posts are located in the `_posts` directory.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ according to the level of appointment as detailed in the table below.
 | 3     | Junior Research Software Engineer |
 
 Details of alumni of the RSE team are kept and this is defined by the `alumnum` field. Whilst a member of the team this
-should be `false` and their profile will be listed under _Contact > Alumni_, but after having left the team it should
+should be `false` and their profile will be listed under _Contact > RSE TEAM_, but after having left the team it should
 be `true` which means their details will be listed under _Contact > Alumni_.
 
 ### Blog Posts

--- a/_people/neil-shephard.md
+++ b/_people/neil-shephard.md
@@ -12,16 +12,17 @@ Neil has taken a convoluted path to reach his current role as research software 
 undergraduate (_BSc Zoology and Genetics_) and post-graduate (_MSc in Genetic Epidemiology_) at _The University
 of Sheffield_ he spent a number of years as a _Genetics Statistician_ researching the aetiology of complex human
 diseases learning UNIX system administration and [literate programming](https://en.wikipedia.org/wiki/Literate_programming)
-along the way at. He then shifted careers to medical statistics and spent eight years working at the
-[Clinical Trials Research Unit](https://www.sheffield.ac.uk/scharr/research/centres/ctru) at the University
-of Sheffield. Throughout this time Neil developed and became enthusiastic about reproducible research and
+along the way at _University of Manchester_, and _University of Western Australia_ before returning to _University
+of Sheffield_. He then shifted careers to medical statistics and spent eight years working at the
+[Clinical Trials Research Unit](https://www.sheffield.ac.uk/scharr/research/centres/ctru) at the _University
+of Sheffield_. Throughout this time Neil developed and became enthusiastic about reproducible research and
  developed practical approaches to achieveing reproducible research in [R](https://www.r-project.org) using
- RMarkdown.
+ [RMarkdown](https://rmarkdown.rstudio.com).
 
 In 2018 he left academia for the private sector working for a telematics company using data captured from
 mobile phones and "_black boxes_" to quantify drivers behaviour. Here he developed an understanding of working
-with geo-spatial data and learnt Python along with various aspects of good software development practice and
-version control of software using Git.
+with geo-spatial data and learnt [Python](https://www.python.org) along with various aspects of good software
+development practice and version control of software using [Git](https://git-scm.com).
 
 Current projects:
 
@@ -30,8 +31,8 @@ Current projects:
 Interests include:
 
 * Reproducible research and literate progrmaming
-* Python and R and Bash
-* Genetics
+* Python, R and Bash
+* Evolutionary Genetics
 * Emacs and Org-mode
 
 Contact:


### PR DESCRIPTION
Thanks for the feedback on #565, I've added some info to the `README.md` on updating biographies of staff members and denoting people as Alumni of the team.

Also tweaked my own bio with minor bits of information and links.