### PR TITLE
540 | Removing link as per issue

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -50,7 +50,4 @@ title: RSE Sheffield Blog
     <span class="next ">Next</span>
   {% endif %}
 </div>
-<div class="all-posts">
-<a href="/blog/all" class="small">Directory of Posts</a>
-</div>
 </div>


### PR DESCRIPTION
Resolves #540 

Very minor, no discussion on whether the "all" page should be reinstated since February so removing link and its associated `<div>`.