### PR TITLE
add "webrick" for ruby 3?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,5 @@ gem "jekyll-redirect-from"
 
 # Emojis https://github.com/jekyll/jemoji
 gem "jemoji"
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Turns out this is needed to serve with ruby 3 but I don't understand ruby, bundler or jekyll so hopefully @ptheywood will be able to say!