### PR TITLE
update code clinic cancellation instructions

### DIFF
--- a/pages/support/code-clinic.md
+++ b/pages/support/code-clinic.md
@@ -83,8 +83,8 @@ relevant upcoming training sessions, etc.
 ### Cancelling your session
 
 If you cannot attend the session,
-please give a **No** response on the calendar invite
-so we can proceed to remove your booking from the system.
+please contact the code clinic helpers at `code-clinic-helpers-group@sheffield.ac.uk` to cancel your session
+and free it up for someone else.
 
 ### Any questions before your session?
 


### PR DESCRIPTION
We're (temporarily) stopping automatic cancellation of the code clinics due to a stubborn bug in the cancellation system, this updates the instructions on the website.

I've also updated the google apps script that sends the confirmation email.