### PR TITLE
Change flake8 url for pre-commit to the new github address

### DIFF
--- a/_posts/2022-10-10-pre-commit.md
+++ b/_posts/2022-10-10-pre-commit.md
@@ -145,7 +145,7 @@ indenting to be valid YAML).
         - id: black
           types: [python]
 
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/pycqa/flake8.git
     rev: 3.9.2
     hooks:
         - id: flake8


### PR DESCRIPTION
Hopefully avoids people like me trying out the examples in the blog and getting errors.