### PR TITLE
Re-order to be more logical; typo/grammar; correct link to linting

### DIFF
--- a/_posts/2022-12-22-git-blame.md
+++ b/_posts/2022-12-22-git-blame.md
@@ -19,20 +19,6 @@ contact the author and gain some insight.
 
 <!--more-->
 
-# Alias
-
-Some people don't like the pejorative nature of the world _blame_. That's ok though, with a tweak to your configuration
-its possible to alias _praise_ people or simply as _who_.
-
-```bash
-# blame alias
-git config --global alias.praise blame
-git praise -L1,30 git_blame.org
-# who alias
-git config --global alias.who blame
-git who -L1,30 git_blame.org
-```
-
 # Usage
 
 Git blame works on individual files and so requires a filename, there are a host of options, for example `-e` prints the
@@ -48,10 +34,25 @@ git blame -e -w -L 10,20 f923la git_blame.org
 For more detailed information on the array of options refer to the [official
 documentation](https://www.git-scm.com/docs/git-blame) or see `git blame --help`.
 
+# Alias
+
+Some people don't like the pejorative nature of the word _blame_. That's ok though, with a tweak to your configuration
+its possible to use the alias _praise_ or simply _who_ instead.
+
+```bash
+# blame alias
+git config --global alias.praise blame
+git praise -L1,30 git_blame.org
+# who alias
+git config --global alias.who blame
+git who -L1,30 git_blame.org
+```
+
+
 # Ignoring blame
 
 Sometimes the case arises where you want to ignore blame. Perhaps the most common example is when an existing code base
-has been [linted](../linting) to conform to a particular style guide. Looking at who performed these changes is not
+has been [linted](pre-commit) to conform to a particular style guide. Looking at who performed these changes is not
 informative and masks who made the changes and why.  Its possible to ignore specific commits on the command line with
 `--ignore-revs <hash> <file>`, but it will quickly become tedious to remember to ignore all blame across multiple
 commits. Fortunately you can save the commits to ignore to the file `.git-blame-ignore-revs` (along with comments) so


### PR DESCRIPTION
Typically after publishing I re-read it again and notice errors (despite having stuck it on my personal blog, re-read it and not noticed any problems).

* Figure its more logical to have **Usage** before **Alias**
* Typo (`world > word`) and better grammar in **Alias**.
* Correcting link to previous linting article.