### PR TITLE
Bump GitHub Action checkout version 2 > 3.5.0

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,4 +1,4 @@
-name: CI build 
+name: CI build
 on:
   pull_request:
     branches:
@@ -14,7 +14,7 @@ jobs:
       USE_HTMLPROOFER: '0'
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
 
       # Install Ruby
       - name: Install Ruby
@@ -39,14 +39,14 @@ jobs:
 
       # Check for broken links if enabled
       - name: Check for broken links
-        if: ${{ env.USE_HTMLPROOFER == '1' }} 
+        if: ${{ env.USE_HTMLPROOFER == '1' }}
         run: |
           bundle exec htmlproofer --disable-external --allow-hash-href --internal-domains=rse.shef.ac.uk,rse.sheffield.ac.uk --log-level :debug ./_site &> links.log
         continue-on-error: true
 
-      # Store the list of potentially broken links 
+      # Store the list of potentially broken links
       - name: Archive log links
-        if: ${{ env.USE_HTMLPROOFER == '1' }} 
+        if: ${{ env.USE_HTMLPROOFER == '1' }}
         uses: actions/upload-artifact@v1
         with:
           name: links-check.log

--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
 
       # Install Ruby
       - name: Install Ruby


### PR DESCRIPTION
Actions are throwing the following warnings...

```
Linux
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

To resolve this the `actions/checkout@v2` has been bumped to `actions/checkout@v3.5.0`