### PR TITLE
add plugin to open external links in new tab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,5 @@ gem "jekyll-redirect-from"
 gem "jemoji"
 
 gem "webrick", "~> 1.7"
+
+gem 'jekyll-target-blank'

--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,7 @@ plugins:
   - jekyll-redirect-from
   - jekyll-paginate
   - jemoji
+  - jekyll-target-blank
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
Trying out using [this plugin](https://github.com/keithmifsud/jekyll-target-blank) to open all external links (i.e. urls not matching the one in `_config.yml`) in a new tab (i.e. adds `target="_blank" rel="noopener noreferrer"` attributes to the `a` tags.

Have not succeeded in testing locally since it's not served to the URL in `_config.yml` but I personally wouldn't mind testing in production since it's relatively harmless.