### PR TITLE
Lint MOD045: Images should have alt text

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -19,9 +19,8 @@ config:
       - script
       - strong
 
-# ignores:
-
-# - ""
+  ignores:
+    - "assets/plugins/"
 
 # Fix any fixable errors
 

--- a/_events/lunchbytes-2022-05-19.md
+++ b/_events/lunchbytes-2022-05-19.md
@@ -18,7 +18,7 @@ In this edition of LunchBytes, we'll be getting together to show off our favouri
 Think: command line tools, IDE plugins, GitHub/Lab features etc.
 
 
-![](https://assets.website-files.com/6167686a04de0ebe0681d0c4/620193f40010d74e1b1aabfc_gitsave-300x2101.png)
+![A sign which reads: "Incase of fire; 1. git commit, 2. git push, 3. leave building.](https://assets.website-files.com/6167686a04de0ebe0681d0c4/620193f40010d74e1b1aabfc_gitsave-300x2101.png)
 
 
 # Speakers

--- a/_events/lunchbytes-2022-10-20.md
+++ b/_events/lunchbytes-2022-10-20.md
@@ -26,7 +26,7 @@ Our speaker this month was Dr Ilse Daly who told us about her journey from visio
 
 *Sounds easy right: have an idea, write the app, sell the app... Turns out that's not entirely how it works, as I'll show in this talk.*
 
-![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Odontodactylus_scyllarus_R%C3%A9union.jpg/640px-Odontodactylus_scyllarus_R%C3%A9union.jpg)
+![Odontodactylus scyllarus, commonly known as the peacock mantis shrimp, harlequin mantis shrimp, painted mantis shrimp, clown mantis shrimp or rainbow mantis shrimp observed at la Réunion (western Indian ocean).](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Odontodactylus_scyllarus_R%C3%A9union.jpg/640px-Odontodactylus_scyllarus_R%C3%A9union.jpg)
 
 Image: Cédric Péneau via [Wikimedia](https://commons.wikimedia.org/wiki/File:Odontodactylus_scyllarus_R%C3%A9union.jpg)
 

--- a/_newsletters/2020-12-03-newsletter.md
+++ b/_newsletters/2020-12-03-newsletter.md
@@ -176,7 +176,7 @@ Euler Problem 1―Multiples of 3 and 5―is:
   into a PNG file or other graphic format.
   The shell script to generate the network graphic:
 
-    ```
+    ```dot
     dot -Tpng > graph.png <<EOF
     digraph G {
       a -> {b1 b2} -> {c1 c2} -> d

--- a/_posts/2016-05-23-fun-with-strace.md
+++ b/_posts/2016-05-23-fun-with-strace.md
@@ -30,12 +30,12 @@ I'm becoming a fan of `strace` for this sort of debugging.
 
 Have a look at this. When I run this command:
 
-```
+```sh
 strace -e signal= -e open bash -l -c 'echo SCRIPT GOT HERE'
 ```
 I get this output (long and boring, skip and come back to the
 bits I refer to):
-```
+```text
 open("/etc/ld.so.cache", O_RDONLY)      = 3
 open("/lib64/libtinfo.so.5", O_RDONLY)  = 3
 open("/lib64/libdl.so.2", O_RDONLY)     = 3

--- a/_posts/2016-05-26-HPC-maple.md
+++ b/_posts/2016-05-26-HPC-maple.md
@@ -41,7 +41,7 @@ Here is an example **.maple** worksheet and the corresponding **.mpl** Maple Lan
 * [run_maple_job.sh](/assets/maple/hpc1/run_maple_job.sh) - Job submission script
 
 If you look at the **.mpl** file in a text editor, you will see that it contains plain text versions of all the Maple input commands that were present in the original worksheet.
-```
+```mpl
 myseries := series(sin(x), x = 0, 10);
 poly := convert(myseries, polynom);
 plot(poly, x = -2*Pi .. 2*Pi, y = -3 .. 3);
@@ -51,7 +51,7 @@ This is the file that we can run on the HPC system in batch mode.
 
 The **job submission script** is a set of instructions to the HPC system's scheduler. It tells the system how much memory you want to use, what program you want to run and so on.  Here is its contents
 
-```
+```sh
 !/bin/bash
 # Request 4 gigabytes of real memory (mem)
 # and 4 gigabytes of virtual memory (mem)
@@ -69,18 +69,18 @@ To run the example on the system:
 * Transfer **series_example.mpl** and **run_maple_job.sh** to a directory on the HPC system. They both need to be in the same directory.
 * Log in to the system using a command line terminal and **cd** to the directory containing the files.
 * Use the **ls** command to confirm you really are in the right directory. You should see something like this:
-```
+```sh
 [ab1test@testnode02 maple_example]$ ls
 
 run_maple_job.sh  series_example.maple  series_example.mpl
 ```
 * Submit the job to the queue with the **qsub** command
-```
+```sh
 qsub run_maple_job.sh
 ```
 
 * You should see something like
-```
+```sh
 [ab1test@testnode02 maple_example]$ qsub run_maple_job.sh
 
 Your job 1734126 ("run_maple_job.sh") has been submitted
@@ -92,7 +92,7 @@ The job number will differ from the one above. It is automatically allocated by 
 
 * Run the **ls** command again to see the results files.
 
-```
+```sh
 [te1st@testnode02 maple_example]$ ls
 
 run_maple_job.sh  run_maple_job.sh.e1734126  run_maple_job.sh.o1734126  series_example.maple  series_example.mpl
@@ -111,7 +111,7 @@ This completes your first batch submission using Maple.
 
 The Maple worksheet we used in this example includes a plot command. This looks great in a Maple worksheet but looks very retro when performed in batch mode!
 
-```
+```text
 > plot(poly, x = -2*Pi .. 2*Pi, y = -3 .. 3);
 
                                       3+                                 H     
@@ -140,7 +140,7 @@ The Maple worksheet we used in this example includes a plot command. This looks 
 
 You probably want to have something that looks a little nicer. The way to do this is to modify the Maple plot command so that it specifies an output file. For example, if we want to create a .gif file, our Maple Language File becomes
 
-```
+```mpl
 myseries := series(sin(x), x = 0, 10);
 poly := convert(myseries, polynom);
 

--- a/_posts/2016-09-12-intel_R_iceberg.md
+++ b/_posts/2016-09-12-intel_R_iceberg.md
@@ -126,7 +126,7 @@ Run time of these operations compared to Iceberg's standard install of R is show
   </tr>
 </table>
 
-![](/assets/images/matmul_r_intel.png)
+![A graph demonstrating the execution time of four different versions of matrix multiplication with R](/assets/images/matmul_r_intel.png)
 
 Another way of viewing these results is to see the speed up compared to the standard install of R. **Even on a single CPU core, the Intel builds are between 4 and 11 times faster than the standard builds**.  Making use of 16 cores takes this up to **141 times faster in the case of Matrix-Matrix Multiplication**!
 

--- a/_posts/2017-03-20-sge-job-validation.md
+++ b/_posts/2017-03-20-sge-job-validation.md
@@ -44,7 +44,7 @@ One way of doing this is to run '``qalter -w v <myjobid>``' after job submission
 if say you think that a job has now been queueing for longer 
 than previously-submitted jobs of a similar nature:
 
-```
+```bash
 [te1st@sharc-login1 ~]$ qalter -w v 217834
 Job 217834 (-l h_rt=3600000) cannot run in queue "flybrain.q" because of cluster queue
 Job 217834 (-l h_rt=3600000) cannot run in queue "gpu.q" because of cluster queue
@@ -119,7 +119,7 @@ you'll observe the same behaviour: jobs that make requests unsatisfiable under t
 Again, job validation can help here but depending on the type of resource the validation error messages can be more or less cryptic.  
 For example, if you try to validate a 100000-'slot' (core) MPI job using ``-w v`` you get the following:
 
-```
+```bash
 qsub -pe mpi 100000 -w v somejob.sge
 ...
 Job 311838 cannot run in PE "mpi" because it only offers 0 slots

--- a/_posts/2017-04-01-mpi_placement.md
+++ b/_posts/2017-04-01-mpi_placement.md
@@ -12,7 +12,7 @@ type: text
 
 Say you request a 16 slot MPI job on ShARC with 3GB per-process using a submission script like the one below:
 
-```
+```sh
 #!/bin/bash
 #Tell the scheduler that maximum runtime is 1 hour
 #$ -l h_rt=1:00:00
@@ -30,9 +30,9 @@ mpirun  ./MPI_hello_world
 
 The scheduler is free to decide where on the system your 16 slots get placed. You may have all 16 slots running on one node, one slot per node for 16 nodes or anything in between. The exact placement of your jobs may affect runtime.
 
-We can find out where the scheculer placed your MPI processes using the `$PE_HOSTFILE` environment variable. When your job starts running, this points to a file that contains placement information. We make use of it in a submission script as follows
+We can find out where the scheduler placed your MPI processes using the `$PE_HOSTFILE` environment variable. When your job starts running, this points to a file that contains placement information. We make use of it in a submission script as follows
 
-```
+```sh
 #!/bin/bash
 #Tell the scheduler that maximum runtime is 1 hour
 #$ -l h_rt=1:00:00
@@ -51,7 +51,7 @@ cat $PE_HOSTFILE  > node_info.txt
 mpirun  ./MPI_hello_world
 ```
 You'll now get a file called `node_info.txt` that contains information about which nodes your MPI slots were placed. For example
-```
+```text
 sharc-node031.shef.ac.uk 1 shortint.q@sharc-node031.shef.ac.uk UNDEFINED
 sharc-node069.shef.ac.uk 1 shortint.q@sharc-node069.shef.ac.uk UNDEFINED
 sharc-node112.shef.ac.uk 1 shortint.q@sharc-node112.shef.ac.uk UNDEFINED

--- a/_posts/2017-04-19-Fortran2017.md
+++ b/_posts/2017-04-19-Fortran2017.md
@@ -14,7 +14,7 @@ In February, the Research Software Engineering group hosted an ‘Introduction t
 
 During the day, Ian recommended a bunch of books (below)
 
-![](/assets/images/fortran_books.jpg){: .img-fluid}
+![A photograph showing 5 books about Fortran; The Fortran 2003 Handbook, Fortran 95/2003 for Scientists and Engineers, Modern Fortran: Style and Usage, Modern Fortran in Practice, Modern Fortran Explained.](/assets/images/fortran_books.jpg){: .img-fluid}
 
 We’ve been working with the University library and I’m happy to announce that all of these are now available to borrow. Search for them using the [University catalogue](https://find.shef.ac.uk/primo_library/libweb/action/search.do)
 

--- a/_posts/2017-06-15-tmux-intro.md
+++ b/_posts/2017-06-15-tmux-intro.md
@@ -40,7 +40,7 @@ Have you ever?
 If the answer to any of these is "yes" then **terminal multiplexing**
 may help!
 
-![](/assets/images/tmux-intro/intro.png){: .img-fluid}
+![A screenshot of a terminal window split into four. Across the four terminals reads "Making remote -- Linux/Unix machines -- easer -- to use!"](/assets/images/tmux-intro/intro.png){: .img-fluid}
 
 ------------------------------------------------------------------------
 

--- a/_posts/2017-06-26-mozsprint-2017.md
+++ b/_posts/2017-06-26-mozsprint-2017.md
@@ -87,7 +87,7 @@ super motivated, self-described crypto nerd from Brisbane, Australia,
 [**Aletheia**](https://github.com/aletheia-foundation/aletheia-admin)
 doesn't pull any punches when describing it's reason for being:
 
-![](https://raw.githubusercontent.com/annakrystalli/random_repo/master/images/aletheia.png){: .img-fluid}
+![Ok, so why does this project exist?: A large percentage of scientific papers published are behind paywalls. That is to say, a huge segment of the world's population is cut off from scientific knowledge. Don't take our word for it. Here, here, here and here are some links to get you started reading about this problem. Paywalls entrench economic privilege, lower global standards and stifle global innovation. Humanity as an entire race loses out, and that means you. You lose, no matter who you are.](https://raw.githubusercontent.com/annakrystalli/random_repo/master/images/aletheia.png){: .img-fluid}
 
 <br>
 
@@ -241,7 +241,7 @@ I just wanted to highlight some basic stats:
 -   **2223** comments & issues
 -   **824** commits pushed
 
-![](https://cdn-images-1.medium.com/max/2000/1*75Nv4-7XCOcnjA9PRjt9sA.png){: .img-fluid}
+![A bar chart titled "50 hours of #mozsprint GitHub Activity by Repo", the X axis is labeled Date and Time (UTC), the Y axis is labelled GitHub Events.](https://cdn-images-1.medium.com/max/2000/1*75Nv4-7XCOcnjA9PRjt9sA.png){: .img-fluid}
 
 **BOOM!**
 ---------

--- a/_posts/2017-11-02-hacktoberfest.md
+++ b/_posts/2017-11-02-hacktoberfest.md
@@ -9,7 +9,7 @@ link:
 description:
 type: text
 ---
-![](/assets/images/Hacktoberfest17-728x90-03.png)
+![A banner reading; "Hacktoberfest: Contribute to open source. Get a free limited-edition T-shirt"](/assets/images/Hacktoberfest17-728x90-03.png)
 
 <br>
 

--- a/_posts/2017-12-21-opencon.md
+++ b/_posts/2017-12-21-opencon.md
@@ -11,7 +11,7 @@ type: text
 ---
 
 
-![](https://d3n8a8pro7vhmx.cloudfront.net/righttoresearch/pages/1462/features/original/OpenCon_2017_London_-_NB_Banner.png?1505763567){: .img-fluid}
+![The logo for OpenCon 2017: London.](https://d3n8a8pro7vhmx.cloudfront.net/righttoresearch/pages/1462/features/original/OpenCon_2017_London_-_NB_Banner.png?1505763567){: .img-fluid}
 
 
 Building on the success of last year’s [**#Reprohack2016**](https://annakrystalli.shinyapps.io/OpenConBerlin_reprohack/) for the Berlin OpenCon satellite event, I rejoined the team of organisers ([Laura Wheeler](https://twitter.com/laurawheelers), [Jon Tennant](https://twitter.com/Protohedgehog) and [Tony Ross-Hellauer](https://twitter.com/tonyR_H) ) and teamed up with [Peter Kraker](https://twitter.com/PeterKraker?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor) to develop the hackday for this year’s [**OpenCon London 2017**](https://www.eventbrite.co.uk/e/opencon-london-2017-open-for-what-tickets-38036414941#).  

--- a/_posts/2018-09-25-hacktoberfest-2018.md
+++ b/_posts/2018-09-25-hacktoberfest-2018.md
@@ -17,7 +17,7 @@ type: text
 
 <br>
 
-![](https://hacktoberfest.digitalocean.com/assets/logo-hacktoberfest-658b5aa2bd34e782d29c40bf6afbdff00f20fe1328efa6da17743878ba8db66f.png){: .img-fluid}
+![A banner reading; "Hacktoberfest 2018: Contribute to open source and get a free limited-edition T-shirt", it also mentions three companies; DigitalOcean, GitHub, twilio](/assets/images/hacktoberfest_banner.png){: .img-fluid}
 
 
 <br>
@@ -68,5 +68,3 @@ By the end hopefully you'll have had an opportunity to learn more about collabor
 
 ### Hope to see you there!
 
-
-![](/assets/images/hacktoberfest_banner.png){: .img-fluid}

--- a/_posts/2020-06-23-git-rebase-vs-merge.md
+++ b/_posts/2020-06-23-git-rebase-vs-merge.md
@@ -28,13 +28,13 @@ There are actually two types of merge which can occur;
 If the branches `master` and `topic` both contain new commits, a true merge will be applied. This essentially creates a new merge commit with parents from both of the branches being merged.
 
 If we call `git merge topic`, whilst the current branch is `master`
-```
+```text
       A---B---C topic
      /
 D---E---F---G master
 ```
 becomes
-```
+```text
       A---B---C topic
      /         \
 D---E---F---G---H master
@@ -46,13 +46,13 @@ In contrast, when the head of the current branch exists within the history of th
 
 If we call `git merge topic`, whilst the current branch is `master`
 
-```
+```text
       C---D---E topic
      /
 A---B master
 ```
 becomes
-```
+```text
                    topic
                  /
 A---B---C---D---E master
@@ -70,13 +70,13 @@ In contrast, `git rebase` incorporates changes from the current branch to the he
 More explicitly, it rolls back all commits on the current branch until a common point in history between the current and named branches is found. All commits after that point in the named branch are then fast-forward merged into current. Following the initially rolled back commits are reapplied individually.
 
 Therefore using the earlier example, if we instead call `git rebase master`, whilst the current branch is `topic`
-```
+```text
       A---B---C topic
      /
 D---E---F---G master
 ```
 becomes
-```
+```text
               a---b---c topic
              /
 D---E---F---G master
@@ -112,7 +112,7 @@ Furthermore `git rebase` can be very powerful, by using the `--interactive` flag
 
 When you first call `git rebase --interactive`, git opens your text editor and presents the below message
 
-```
+```text
 # Rebase AAAAAA..BBBBBB onto CCCCCC (N commands)
 #
 # Commands:

--- a/_posts/2022-05-05-reproducible-matlab.md
+++ b/_posts/2022-05-05-reproducible-matlab.md
@@ -222,7 +222,7 @@ Similarly to what we saw above, an error will be raised if the wrong result is p
 
 We can run all of our tests for a project from the MATLAB desktop under the *Editor* tab, including running tests with the debugger.
 
-![](/assets/images/matlab-repro-blog/run-tests.png)
+![A screenshot of MATLAB's Run tests toolbar, it has four buttons: Run Tests (with a dropdown arrow), Run Current test, Step (disabled), Stop (disabled).](/assets/images/matlab-repro-blog/run-tests.png)
 
 #### Next steps in testing
 As mentioned above, MATLAB provides more featureful tools for testing under the [class-based testing framework](https://uk.mathworks.com/help/matlab/class-based-unit-tests.html); tools for [testing applications](https://uk.mathworks.com/help/matlab/app-testing-framework.html) and more. I may put together a blog post on these in the future.

--- a/_posts/2022-05-05-reproducible-matlab.md
+++ b/_posts/2022-05-05-reproducible-matlab.md
@@ -60,7 +60,7 @@ Use folders/directories to organise your project, so that it is obvious (to you 
 
 At the very top level of your project, why not have something like the following structure?
 
-```
+```text
 ├── data/             # directory to contain your data
 │   └── raw/          # all your raw, unprocessed data
 │   └── processed/    # any data that you have altered

--- a/_posts/2022-08-18-git-tools.md
+++ b/_posts/2022-08-18-git-tools.md
@@ -105,7 +105,7 @@ GitKraken Client is one of [very many local interfaces to git](https://git-scm.c
 
 GitKraken client provides all the tools you need for working with git locally as well as remote repositories hosted on GitHub, GitLab, BitBucket or Azure. It has an aesthetically-pleasing and very visual interface which can be used to: make and push commits, manage branches and remotes, manage pull requests and even has a basic text file editor built in. I'd highly recommend it as a user-friendly way of working with version control.
 
-![](/assets/images/blog-git-tools/gitkrakenclient.png)
+![A screenshot of GitKraken's graph view of a repository's commit.](/assets/images/blog-git-tools/gitkrakenclient.png)
 
 * [GitKraken Client](https://www.gitkraken.com/git-client)
 

--- a/_posts/2022-10-10-pre-commit.md
+++ b/_posts/2022-10-10-pre-commit.md
@@ -82,7 +82,7 @@ conda install -c conda-forge pre-commit
 If you are working on a Python project then you should include `pre-commit` as a requirement (either in
 `requirements-dev.txt`) or under the `dev` section of `[options.extras_require]` in your `setup.cfg` as shown below.
 
-```
+```cfg
 [options.extras_require]
 dev =
   pre-commit

--- a/_posts/2022-10-20-better-code.md
+++ b/_posts/2022-10-20-better-code.md
@@ -38,7 +38,7 @@ Instead, use a variable name that describes its content, such as `temperature_re
 ## 1. Don't reuse variables
 This concept may follow from using well-named variables. For instance, if your code performs some data cleaning and validation, each operation should assign a new variable.
 
-```
+```py
 data = "data/data.csv"
 
 data = read_data(data)
@@ -50,7 +50,7 @@ data = validate_data(data)
 
 is a lot less readable than
 
-```
+```py
 data_path = "raw_data/01readings.csv"
 
 raw_data = read_data(data_path)
@@ -67,8 +67,8 @@ If you do the same job at many places throughout your code, instead of copying t
 Functions take input variables (known as arguments), perform some operation and return a result.
 In the above pseudocode example, `read_data()` might look like this:
 
-```
-function read_data(filepath):
+```py
+def read_data(filepath):
     data = read_csv(filepath)
     return data    
 ```

--- a/assets/plugins/jquery-scrollTo/README.md
+++ b/assets/plugins/jquery-scrollTo/README.md
@@ -2,7 +2,7 @@
 
 Lightweight, cross-browser and highly customizable animated scrolling with jQuery
 
-[![](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/2081384/fleslerjquery-scrollTo-on-GitHub)
+[![Flattr badge](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/2081384/fleslerjquery-scrollTo-on-GitHub)
 [![GitHub version](https://badge.fury.io/gh/flesler%2Fjquery.scrollTo.svg)](http://badge.fury.io/gh/flesler%2Fjquery.scrollTo)
 [![libscore](http://img.shields.io/badge/libscore-31656-brightgreen.svg?style=flat-square)](http://libscore.com/#jQuery.fn.scrollTo)
 

--- a/assets/plugins/jquery-scrollTo/README.md
+++ b/assets/plugins/jquery-scrollTo/README.md
@@ -2,7 +2,7 @@
 
 Lightweight, cross-browser and highly customizable animated scrolling with jQuery
 
-[![Flattr badge](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/2081384/fleslerjquery-scrollTo-on-GitHub)
+[![](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/2081384/fleslerjquery-scrollTo-on-GitHub)
 [![GitHub version](https://badge.fury.io/gh/flesler%2Fjquery.scrollTo.svg)](http://badge.fury.io/gh/flesler%2Fjquery.scrollTo)
 [![libscore](http://img.shields.io/badge/libscore-31656-brightgreen.svg?style=flat-square)](http://libscore.com/#jQuery.fn.scrollTo)
 

--- a/pages/community/resources-and-equipment/languages/maple.md
+++ b/pages/community/resources-and-equipment/languages/maple.md
@@ -10,7 +10,7 @@ description:
 type: text
 ---
 
-![](/assets/images/Maplesoft_logo.svg)
+![The Maplesoft logo](/assets/images/Maplesoft_logo.svg)
 
 Maple is a computer algebra system developed and sold commercially by Maplesoft, a software company based in Waterloo, Ontario, Canada.
 The University of Sheffield has a site license that allows all staff and students to use it on University and personal machines.

--- a/pages/community/resources-and-equipment/languages/mathematica.md
+++ b/pages/community/resources-and-equipment/languages/mathematica.md
@@ -19,4 +19,4 @@ The University of Sheffield has a site license that allows all staff and student
       * [ShARC](https://docs.hpc.shef.ac.uk/en/latest/sharc/software/apps/mathematica.html)
   * [Mathematica Code Cafe](https://github.com/RSE-Sheffield/Code_cafe/tree/master/WolframCodeCafe) - Basic training for Mathematica delivered as part of our Code Cafe series
 
-![](/assets/images/Mathematica.png)
+![Wolfram Mathematica's logo](/assets/images/Mathematica.png)

--- a/pages/training/com4521/hpc-sharc.md
+++ b/pages/training/com4521/hpc-sharc.md
@@ -66,13 +66,13 @@ The below guide explains how to use [FileZilla](https://filezilla-project.org), 
 To login enter the following command in your terminal, replacing `$USER` with your university username e.g. `acb12de`.
 
 
-```
+```sh
 ssh $USER@sharc.shef.ac.uk
 ```
 
 You will then be prompted to enter you password
 
-```
+```text
 Password:
 ```
 
@@ -80,7 +80,7 @@ On password confirmation you will be prompted to select a MFA option.
 
 Either enter a passcode directly from the Duo mobile app, or enter `1` and respond to the push notification.
 
-```
+```text
 Duo two-factor login for $USER
 
 Enter a passcode or select one of the following options:
@@ -92,7 +92,7 @@ Passcode or option (1-1):
 
 If login was successful you should see a success message and login welcome.
 
-```
+```text
 Success. Logging you in...
 *****************************************************************************
 *         ShARC (Sheffield Advanced Research Computer) HPC cluster          *
@@ -149,7 +149,7 @@ On success you should see the prompt change from `@sharc-login` to `@sharc-node`
 
 To leave the interactive session you can call `exit`.
 
-```
+```sh
 [$USER@sharc-login2 ~]$ qrshx
 [$USER@sharc-node009 ~]$ exit
 exit
@@ -160,7 +160,7 @@ exit
 
 Lots of software is installed on the HPC system, therefore to prevent conflicts it is necessary to manually load the required software.
 
-```
+```sh
 module load libs/CUDA/11.6.0/binary
 module load dev/gcc/8.2
 ```
@@ -175,7 +175,7 @@ If you navigate to where you have uploaded your assignment code (e.g. `cd com452
 
 *The output below is normal for compilation success, it merely shows the commands passed to the two compilers.*
 
-```
+```text
 [$user@sharc-node009 com4521_assignment]$ make
 nvcc -c -o build/release/src/main.cu.o src/main.cu -gencode arch=compute_35,code=sm_35 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_60,code=compute_60 -I. -Isrc -Wno-deprecated-gpu-targets -lineinfo -O3 -DNDEBUG -Xcompiler -fopenmp -Xcompiler -I. -Xcompiler -Isrc -Xcompiler -Wall -Xcompiler -O3 -Xcompiler -DNDEBUG
 gcc -c -o build/release/src/helper.c.o src/helper.c -fopenmp -I. -Isrc -Wall -O3 -DNDEBUG
@@ -188,7 +188,7 @@ nvcc -o bin/release/Particles build/release/src/main.cu.o build/release/src/help
 
 Errors and warnings take the below form. The exact messages may differ from those you receive in Visual Studio, but the code you are working with should remain cross-platform.
 
-```
+```text
 src/cuda.cu(45): error: expected a ";"
 ```
 
@@ -205,7 +205,7 @@ The header of the job script contains a large number of parameters which can be 
 
 To submit the default job scripts call the desired command below from the root of your project:
 
-```
+```sh
 qsub scripts/sharc/run.sh
 qsub scripts/sharc/run_debug.sh
 ```
@@ -224,7 +224,7 @@ It is necessary to install the Visual Profiler to view these outputs. It can be 
 
 To submit the default profiling job script call the below command from the root of your project:
 
-```
+```sh
 qsub scripts/sharc/profile.sh
 ```
 
@@ -270,7 +270,7 @@ The module does not cover usage of the modern profiling tools or interpretation 
 
 Compute sanitizer is available on HPC similar to the managed desktops, it can be executed with the sample job script to memory check Debug builds of your code. As before, **you will need to modify a copy of this script to specify different runtime argument to your application**.
 
-```
+```sh
 qsub scripts/sharc/cudamemchk.sh
 ```
 
@@ -284,13 +284,13 @@ In order to interactively debug your code on HPC it is necessary to get an inter
 
 An interactive GPU session, can be requested with the below command:
 
-```
+```sh
 qrshx -l gpu=1 -P rse -q rse-interactive.q
 ```
 
 If this succeeds, and you have loaded the same two modules required for compilation, you should then be able to use `cuda-gdb` to interactively debug your application.
 
-```
+```sh
 cuda-gdb --args "bin/debug/Particles" CUDA 100 512x512 output_image.png
 ```
 

--- a/pages/training/com4521/labs/4.md
+++ b/pages/training/com4521/labs/4.md
@@ -57,7 +57,7 @@ cudamemchk.bat "x64\Debug\Lab04_Exercise01.exe"
 
 This should produce a log similar to that below, explaining the first memory error detected.
 
-```
+```text
 ========= COMPUTE-SANITIZER
 ========= Invalid __global__ write of size 4 bytes
 =========     at 0x3c8 in U:/com4521/Lab04_Exercise01/exercise01_sln.cu:42:affine_decrypt_multiblock(int*,int*)
@@ -121,20 +121,20 @@ This should produce a log similar to that below, explaining the first memory err
 
 Only the first few lines are really important
 
-```
+```text
 ========= Invalid __global__ write of size 4 bytes
 ```
 
 There was an invalid read from global device memory (something allocated with `cudaMalloc()` or at compile time using `__device__`).
-```
+```text
 =========     at 0x3c8 in U:/com4521/Lab04_Exercise01/exercise01_sln.cu:42:affine_decrypt_multiblock(int*,int*)
 ```
 It occurred at line 42 of `exercise01_sln.cu` in the kernel/function with prototype `affine_decrypt_multiblock(int*,int*)`
-```
+```text
 =========     by thread (0,0,0) in block (0,0,0)
 ```
 It first occurred in thread 0 of block 0. (Without requesting 1 error, this whole error stack would be repeated for every thread with an error, possibly thousands of times).
-```
+```text
 =========     Address 0x4 is out of bounds
 ```
 The bad address in this case was `0x4` (e.g. I forced an error by writing `int *test=0;` `test[1]=12;`).


### PR DESCRIPTION
One of the external images linked by Hacktoberfest 2018 was 404, so replace with image from the bottom of the page and removed the bottom image.

Resolved missing alt-text in assets dir, but this directory should probably be ignored.