### PR TITLE
Fixes error in code block which messed up rendering

### DIFF
--- a/_posts/2023-09-18-python-packaging.md
+++ b/_posts/2023-09-18-python-packaging.md
@@ -87,7 +87,6 @@ requires = ["setuptools>=65.6.3", "setuptools_scm[tools]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 ```
 
-
 ### `project`
 
 This is the main body of the project description detailing `name`, `authors`, `description`, `readme`, `license`, `keywords`,
@@ -372,7 +371,7 @@ build-backend = "setuptools.build_meta"
 
 The package can now be built locally with...
 
-``` {.bash eval="no"}
+``` {.bash}
 python -m pip install --upgrade setuptools wheel
 python -m build --no-isolation
 ```


### PR DESCRIPTION
This article started live in my [org-roam](https://www.orgroam.com/) notes and was exported to Markdown. In the export it retained the code chunk options of whether to evaluate code blocks which Markdown doesn't support and I missed removing one of them when publishing the article.

This removes it and should fix rendering of the relevant section.