### PR TITLE
Sort alumni by level, surname, othernames

### DIFF
--- a/pages/contact/alumni.md
+++ b/pages/contact/alumni.md
@@ -7,7 +7,7 @@ type: text
 
 Previous members of the RSE Sheffield team:
 
-{% assign people = site.people | sort: 'level' | sort: 'surname' | sort: 'othernames'  %}
+{% assign people = site.people | sort: 'othernames' | sort: 'surname' | sort: 'level'  %}
 <div class="people-list">
 {% for person in people %}
     {% if person.alumnum == true %}


### PR DESCRIPTION
Reverses the sort order to match the peoeple page, so the final view is grouped by level, then surname, then othernames.