### PR TITLE
CI: On PR's upload the built site as an artifact for 14 days

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -37,6 +37,16 @@ jobs:
       - name: Build jekyll website with drafts
         run: bundle exec jekyll build --drafts
 
+      # Upload the website as an artifact for previews without local building, within the next 14 days. 
+      - name: Upload Artifact on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: rse.github.io
+          path: _site/
+          if-no-files-found: error
+          retention-days: 14
+
       # Check for broken links if enabled
       - name: Check for broken links
         if: ${{ env.USE_HTMLPROOFER == '1' }}


### PR DESCRIPTION
Uploads the compiled website as an artifact when the CI is triggered by a pull request.

Set to 14 days which should be enough for pr review.