### PR TITLE
add upcoming training list to training page

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ seminar:
 
 To create a new category, add a new YAML element with a unique key to `_data/event-categories.yml`.
 
+Events with categories: `workshop`, `carpentry`, `dltraining` and `gitzerohero` are included in the list on the training page.
+
 #### Creating a new category listing
 
 To create a new page which lists all events of a given category:

--- a/pages/training/index.md
+++ b/pages/training/index.md
@@ -17,7 +17,7 @@ The RSE Team focusses on training in version control as this is a key skill for 
 
 #### Upcoming training
 
-{% include events_list_upcoming.html category="workshop" %}
+{% include events_list_upcoming.html category="workshop,carpentry,gitzerohero,dltraining" %}
 
 
 ### IT Services Training

--- a/pages/training/index.md
+++ b/pages/training/index.md
@@ -15,6 +15,11 @@ The RSE Team focusses on training in version control as this is a key skill for 
 - [git & GitHub through GitKraken - from Zero to Hero!](courses/git_Hero.md)
 - [Introduction to Deep Learning](courses/Intro_DL.md)
 
+#### Upcoming training
+
+{% include events_list_upcoming.html category="workshop" %}
+
+
 ### IT Services Training
 
 Our colleagues in [IT Services][its] offer a range of [free training courses][its-courses]. This is a good place to look if you want to learn how to code, but there are a wide range of other courses there as well.


### PR DESCRIPTION
Adds the upcoming training list to the main training page.

~One issue is that some of the training events have different categories, e.g.`category: dltraining` and not `workshop` - can we filter by multiple values? Or can those events have multiple `category` keys?~