### PR TITLE
Switch to github pages via action + PAT based mirroring

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -14,7 +14,7 @@ jobs:
       USE_HTMLPROOFER: '0'
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
 
       # Install Ruby
       - name: Install Ruby
@@ -47,7 +47,7 @@ jobs:
       # Store the list of potentially broken links
       - name: Archive log links
         if: ${{ env.USE_HTMLPROOFER == '1' }}
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: links-check.log
           path: links.log

--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
 
       # Install Ruby
       - name: Install Ruby

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,13 +34,13 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+          ruby-version: 2.7.4 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
 
       # Install dependencies required to run jekyll build
       - name: Install gh-pages rubygem via bundler
         run: |
-          # Update gem and bundler
-          gem update --system --no-document
+          # Update gem and bundler - disabled due to gem install errors on CI
+          # gem update --system --no-document
           gem update bundler --no-document
           # Set the bundle directory
           bundle config set path vendor/bundle

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,72 @@
+name: publish
+
+# Trigger the workflow on pushes to master, or workflow dispatches from the master branch (checked later)
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Set permissions on the github.token for gh-pages use
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Enable publication to gh pages via actions/deploy-pages@v2
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Enable use of gh
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  build:
+    name: build-for-publish
+    runs-on: ubuntu-latest
+    steps:
+      # Clone the repository and checkout into the relevant branch
+      - uses: actions/checkout@v3.5.0
+
+      # Install Ruby
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+
+      # Install dependencies required to run jekyll build
+      - name: Install gh-pages rubygem via bundler
+        run: |
+          # Update gem and bundler
+          gem update --system --no-document
+          gem update bundler --no-document
+          # Set the bundle directory
+          bundle config set path vendor/bundle
+          # Install Gemfile contents via bundler
+          bundle install
+
+      # Build the website via jekyll
+      - name: Build jekyll website without drafts
+        run: bundle exec jekyll build
+
+      # Save HTML for later
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: _site/
+
+  # If this should deploy (push or workflow dispatch on master) to github pages, do so using the saved artifact
+  # This requires "GitHub Actions" selected in github.com/org/repo/settings/pages
+  deploy:
+    if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) && github.ref == 'refs/heads/master' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,3 +70,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+  
+  # Trigger the build of the rse.sheffield.ac.uk mirror
+  mirror:
+    if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) && github.ref == 'refs/heads/master' && github.repository_owner == 'RSE-Sheffield' }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Use gh to trigger the workflow_dispatch event on the appropriate workflow in another repository.
+      # This step may fail if the PAT is invalid or has expired
+      # If so, create a fine-grained pat with actions: write and permissions on the appropriate repository, storing it in the relevant secret on this repository.
+      - name: Trigger RSE-Sheffield/rse.sheffield.ac.uk
+        env:
+          GH_TOKEN: ${{ secrets.SHEFFIELD_MIRROR_TOKEN }}  # Note that this will periodically need to be renewed
+          REPO: "RSE-Sheffield/rse.sheffield.ac.uk"
+          WORKFLOW: "mirror.yaml"
+        run: |
+          gh workflow run ${WORKFLOW} -R ${REPO}
+          sleep 5
+          gh run watch -R ${REPO} $(gh run list -R ${REPO} -w ${WORKFLOW} -L1 --json databaseId --jq .[0].databaseId)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v4
 
       # Install Ruby
       - name: Install Ruby
@@ -53,7 +53,7 @@ jobs:
 
       # Save HTML for later
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: _site/
 
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
   
   # Trigger the build of the rse.sheffield.ac.uk mirror
   mirror:

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-rse.shef.ac.uk

--- a/README.md
+++ b/README.md
@@ -320,22 +320,23 @@ redirect_from:
 
 ## Deployment and Mirroring
 
-This website is deployed to `rse.shef.ac.uk` via github pages using `GitHub Actions` as the source, and the `.github/workflows/publish.yaml` action.
+This website is deployed to [`rse.shef.ac.uk`](https://rse.shef.ac.uk) via GitHub pages using `GitHub Actions`.
+The `.github/workflows/publish.yaml` workflow is triggered by pushes to `master`, or `workflow_dispatch` events on this repository.
 
-It is deployed by pushes to master, or `workflow_dispatch` events on this repository.
-
-Additionally, this workflow will trigger deployment to `rse.sheffield.ac.uk` on github pages, via the `.github/workflows/mirror.yaml` CI workflow on [RSE-Sheffield/rse.sheffield.ac.uk](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk).
+When this workflow successfully deploys the website, it also triggers a deployment to [`rse.sheffield.ac.uk`](https://rse.sheffield.ac.uk), by triggering the [RSE-Sheffield/rse.sheffield.ac.uk](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk) repositories [`.github/workflows/mirror.yaml`](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk/actions/workflows/mirror.yaml) workflow via `gh`.
 This requires a fine-grained PAT with `actions: read and write` permissions for actions events, storing in a repository secret `SHEFFIELD_MIRROR_TOKEN`.
 The token will need periodically renewing.
+
+The mirror CI workflow can also be manually triggered if needed, by selecting `Run workflow` on [github.com/RSE-Sheffield/rse.sheffield.ac.uk/actions/workflows/mirror.yaml](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk/actions/workflows/mirror.yaml). This should not be necessary, but may be required if the PAT expires or API errors occur.
 
 ### GitHub Settings
 
 * Enable Github pages, with `GitHub Actions` as the source.
 * Set the `custom domain` to `rse.sheffield.ac.uk`
 * Wait up to 24 hours, then enable `Enforce HTTPS`
-* a user with priviledges must [Generate a fine-grained PAT](https://github.com/settings/tokens?type=beta) with
+* a user with privileges must [Generate a fine-grained PAT](https://github.com/settings/tokens?type=beta) with
   * an appropriate name, description and expiration period
-  * the RSE-Sheffield org as the Resource Owner
+  * the `RSE-Sheffield` org as the Resource Owner
   * Access to `Only select repositories`, selecting `RSE-Sheffield/rse.sheffield.ac.uk`
   * Grant `Read and write` permissions for `Actions`
   * Save the PAT to an [action repository secret](https://github.com/RSE-Sheffield/RSE-Sheffield.github.io/settings/secrets/actions) named `SHEFFIELD_MIRROR_TOKEN`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source for the RSE-Sheffield website, built with [Jekyll](https://jekyllrb.com/).
 
-The website is hosted on GitHub Pages and can be found at [https://rse.shef.ac.uk](https://rse.shef.ac.uk).
+The website is hosted on GitHub Pages and can be found at [https://rse.shef.ac.uk](https://rse.shef.ac.uk), and mirrored at [https://rse.sheffield.ac.uk](https://rse.sheffield.ac.uk) by [RSE-Sheffield/rse.sheffield.ac.uk](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk).
 
 All content (excluding logos or where explicitly stated) licensed under the
 <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1"
@@ -317,3 +317,26 @@ A Jekyll plugin has been enabled to help with that: you can create redirects to 
 redirect_from:
   - /events/some-page-that-might-not-exist.html
 ```
+
+## Deployment and Mirroring
+
+This website is deployed to `rse.shef.ac.uk` via github pages using `GitHub Actions` as the source, and the `.github/workflows/publish.yaml` action.
+
+It is deployed by pushes to master, or `workflow_dispatch` events on this repository.
+
+Additionally, this workflow will trigger deployment to `rse.sheffield.ac.uk` on github pages, via the `.github/workflows/mirror.yaml` CI workflow on [RSE-Sheffield/rse.sheffield.ac.uk](https://github.com/RSE-Sheffield/rse.sheffield.ac.uk).
+This requires a fine-grained PAT with `actions: read and write` permissions for actions events, storing in a repository secret `SHEFFIELD_MIRROR_TOKEN`.
+The token will need periodically renewing.
+
+### GitHub Settings
+
+* Enable Github pages, with `GitHub Actions` as the source.
+* Set the `custom domain` to `rse.sheffield.ac.uk`
+* Wait up to 24 hours, then enable `Enforce HTTPS`
+* a user with priviledges must [Generate a fine-grained PAT](https://github.com/settings/tokens?type=beta) with
+  * an appropriate name, description and expiration period
+  * the RSE-Sheffield org as the Resource Owner
+  * Access to `Only select repositories`, selecting `RSE-Sheffield/rse.sheffield.ac.uk`
+  * Grant `Read and write` permissions for `Actions`
+  * Save the PAT to an [action repository secret](https://github.com/RSE-Sheffield/RSE-Sheffield.github.io/settings/secrets/actions) named `SHEFFIELD_MIRROR_TOKEN`
+  * The token/secret will need renewing periodically.


### PR DESCRIPTION
+ [x] Switches from default to custom gh pages deployment via actions
+ [x] on deployment, trigger a CI workflow in the RSE-Sheffield/rse.sheffield.ac.uk repository to mirror the website to rse.sheffield.ac.uk
+ [x] Get rse.sheffield.ac.uk verified for our org
+ [x] rse.sheffield.ac.uk CNAME record
+ [x] Set Cname setting on RSE-Sheffield/rse.sheffield.ac.uk
+ [x] Update actions to be node 16 compatible
+ [ ] Update this repositories setting(s) to be actions based publication (i.e. use our workflow(s). 
Repo settings will need to be changed prior to merging this.
+ [ ] Update the handbook with appropriate information