### PR TITLE
April 2024 Newsletter

### DIFF
--- a/_newsletters/2024-04-04-newsletter.md
+++ b/_newsletters/2024-04-04-newsletter.md
@@ -1,0 +1,247 @@
+---
+layout: post
+title: April 2024 Newsletter
+editor: Neil Shephard
+slug: 2024-04-03-newsletter
+date: 2024-04-03T12:00:00Z+0100
+tags:
+category:
+link:
+description:
+type: text
+---
+
+## The University of Sheffield Research Software Engineering Community Newsletter March 2024
+
+Welcome to the April 2024 newsletter for the research software community at The University of Sheffield, featuring
+news, opportunities, events and training for you.
+
+### News
+
+### Events
+
+#### Upcoming events in Sheffield
+
+<!-- List in chronological order -->
+
+- [ResearchComputing@Sheffield](https://docs.google.com/forms/d/e/1FAIpQLScV3ElzjeKTn3TvbFdz1uDarpXq3EPLGYT2zP51VQbvCJFXtA/viewform)
+  - **2024-04-09 @ 09:30-16:45** the annual event showcasing projects using research computing facilities and how
+    researches access and utilise the facilities.
+- [N8CIR - Synthetic Data Generation Event](https://n8cir.org.uk/events/synthetic-data-generation-event-sheffield/)
+  - **2024-04-17** _Understand, brainstorm and produce synthetic data in your research field_, deadline for applications
+    is **2024-04-11**.
+- [Elev-AI-te: Lunctime workshops on generative AI and Education](https://docs.google.com/document/d/1h1HJGjiSVPao-XAJtZHidtwGLYge8WntQLBwKTvi2LE/edit#heading=h.q9oo06vp2v8a):
+  - Open to all staff at the University of Sheffield these workshops are 15 to 30 minutes face-to-face (unless otherwise
+    specified). The schedule for April and beyond...
+    - [**2024-04-08 @ 12:00** : Dave Holloway - Image
+      Generation](https://mydevelopment.csod.com/samldefault.aspx?returnurl=%252fDeepLink%252fProcessRedirect.aspx%253fmodule%253dlodetails%2526lo%253df2f2d03c-9d14-44e4-a968-3cf91d3ed620)
+    - [**2024-04-24 @ 12:00** : Ali Riley and Laurie Wilson - Authentic assessment and Generative
+      AI](https://mydevelopment.csod.com/samldefault.aspx?returnurl=%252fDeepLink%252fProcessRedirect.aspx%253fmodule%253dlodetails%2526lo%253dda05dc1d-c12b-4cc5-9468-2eef44774bfd)
+    - [**2024-05-07 @ 12:00** : Luke Thompson - Data protection and Generative
+      AI](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/418ec4b1-9b6f-46cd-98ef-16d3a6ccf917)
+    - [**2024-05-23 @ 12:00** : Matt Sutcliffe - Generative AI and
+      Employability](https://mydevelopment.csod.com/samldefault.aspx?returnurl=%252fDeepLink%252fProcessRedirect.aspx%253fmodule%253dlodetails%2526lo%253d323ce590-195c-4461-818f-33bf0c1f376a)
+    - [**2024-06-06 @ 12:00** : Rob Spark, Sophe Ward and Vicky Cartledge-Mann - Generative AI as an Assistive
+      Technology](https://mydevelopment.csod.com/samldefault.aspx?returnurl=%252fDeepLink%252fProcessRedirect.aspx%253fmodule%253dlodetails%2526lo%253d4a4ce5f2-474f-4dd6-a64a-014796330493)
+    - [**2024-06-18 @ 12:00** : Finding reliable information using Generative AI
+      tools](https://mydevelopment.csod.com/samldefault.aspx?returnurl=%252fDeepLink%252fProcessRedirect.aspx%253fmodule%253dlodetails%2526lo%253d59237776-2c5a-4e0e-b2b1-4ed2691c482b)
+- [SheffieldR User Group](https://sheffieldr.github.io/)
+  - **2024-04-22 @ 12:00** RSE Team Member [Dr Dan Brady](https://rse.shef.ac.uk/contact/dan-brady/) will be leading
+    this months [SheffieldR](https://sheffieldr.github.io/) User Group. Please keep an eye on the website,
+    [@sheffieldr@fosstodon.org](https://fosstodon.org/@sheffieldr) or join the [Meetup
+    Group](meetup.com/SheffieldR-Sheffield-R-Users-Group/) where full details will be announced.
+- OpenFest2024
+  - Week commencing **2024-09-09** Sheffields popular OpenFest2024 symposium returns for its third year with in-person
+    events at University of Sheffield (2024-09-10) and Sheffield Hallam University (2024-09-12) and an online symposium
+    (2024-09-11). There will be workshops, presentations, panel discussions and more. Further details and a call for
+    presentations will follow. In the meantime if you've suggestions please get in touch with Open Research Manager [Dr
+    Jenni Adams](mailto:j.adams@sheffield.ac.uk).
+
+#### Upcoming external events
+
+<!-- List in chronological order -->
+
+- [RSECon24](https://rsecon24.society-rse.org/)
+  - **2024-09-03** to **2024-09-05** This years [Research Software Engineering
+    Society](https://rsecon24.society-rse.org/) 2024 conference in Newcastle has seen several key announcements...
+  - [Call for Submissions](https://rsecon24.society-rse.org/calls/submissions/): to deliver _an accessible, celebratory
+    and outward-looking programme_. Deadline for submissions is **2024-05-01**.
+  - [Call for Reviewers](https://rsecon24.society-rse.org/calls/reviewers/): All those submissions don't review
+    themselves and so there is a call for reviewers out too. Deadline for reviewer application is **2024-04-30**.
+  - Finally there is an invitation for [Expression of Interest for Satellite
+    Events](mailto:rsecon24-steering-group@society-rse.org). These would be self-funded or sponsored, half or full-day
+    events either side of the main conference. Please send expression of interest to
+    [rsecon24-steering-group@society-rse.org](mailto:rsecon24-steering-group@society-rse.org) before **2024-04-12** with...
+    - Title
+    - Brief description (150 words max)
+    - Preference for 2024-09-02 or 2024-09-06 if you have one
+    - Expected duration (half or full day)
+    - Estimated and maximum attendance
+
+### Open Research
+
+- [FAIR-Impact 2nd Open Call](https://fair-impact.eu/2nd-open-call-route-2-support):
+  - There is still (just) time to apply for financial support for [Assessment and improvement of Research
+    Software](https://fair-impact.eu/support-offer-1-assessment-and-improvement-research-software). Deadline is
+    2024-04-05.
+- [Hidden Ref 2024 category nominations](https://hidden-ref.org/hidden-ref-award-ceremony/)
+  - The Hidden REF was launched to raise awareness of the research outputs and roles that are vital to research but
+    overlooked by traditional research evaluation and they have an call for category suggestions out.
+- [ERROR: Estimating the Reliability & Robustness Of Research](https://error.reviews/):
+  - ERROR is a bug bounty program for science to systematically detect and report errors in academic publications
+
+### Articles, Blogs, Papers & Podcasts
+
+#### Articles & Blogs
+
+- [The FAIR for Research Software Principles after two years: an adoption update · Research Software
+  Alliance](https://www.researchsoft.org/blog/2024-03/)
+
+#### Podcasts
+
+- [Code for Thought - ByteSized RSE: The Citation File Format with Jason Maassen](https://codeforthought.buzzsprout.com/1326658/14712650-en-bytesized-rse-the-citation-file-format-jason-maassen):
+  - This ByteSized RSE episode talks about the [Citation File Format (CFF)](https://citation-file-format.github.io/),
+    created in 2017 to promote the inclusion of software in scientific papers.
+
+### Training
+
+- Git & GitHub through GitKraken - from Zero to Hero!
+  - An introductory course, teaching the git and GitHub skills required to manage research code over its development
+    lifecycle. These skills are essential for collaborative research teams.
+  - [2024-04-22 & 23 09:30-13:00, Hicks Building Computer Room G34A](https://rse.shef.ac.uk/training/workshop/2024-04-22-git-zero-hero)
+  - [2024-05-20 & 21 09:30-13:00, Information Commons - Computer Room 3
+    (3.02)](https://rse.shef.ac.uk/training/workshop/2024-05-20-git-zero-hero)
+  - [2024-06-24 & 25 09:30-13:00, The Diamond - 206 Computer Room
+    4](https://rse.shef.ac.uk/training/workshop/2024-06-24-git-zero-hero)
+- Performance Profiling and Optimisation (Python)
+  - This course delves into the tools and methodologies used to analyse and enhance the performance of Python
+    programs. You will learn how to profile, analyse and optimise Python code effectively to create high-performance
+    applications.
+  - **2024-04-18 09:00-16:00** Hicks G43a
+  - **2024-05-30 09:00-16:00** Hicks G43a
+  - **2024-06-20 09:00-16:00** Hicks G43a
+  - **2024-07-11 09:00-16:00** Hicks G43a
+  - Book through
+    [myDevelopment](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/fe34df6f-ab5f-49cf-b794-88aba03b3803)
+- [UKRN Open Research Programme - Train the Trainer](https://www.ukrn.org/training-schedule/)
+  - Deadline for applications extended to **2024-04-04** for the following events so you'll have to be quick.
+    - [**2024-05-01** Pre-registration and registered
+      reports](https://www.ukrn.org/training/preregistration-and-registered-reports-1-may/)
+    - [**2024-05-08** Data Sharing](https://www.ukrn.org/training/data-sharing-from-planning-to-publishing-8-may/)
+    - [**2024-05-30 & 31** Reproducible Research
+      Workshop](https://www.ukrn.org/training/reproducible-research-workshop-and-train-the-trainer/)
+    - [**2024-06-05 & 06** Project TIER (Teaching Reproducible
+      Research)](https://www.ukrn.org/training/teaching-reproducible-research-glasgow/)
+    - [**2024-06-05 & 06** VIR2TUE ethics for open
+      research](https://www.ukrn.org/training/virt2ue-train-the-trainer-programauto-draft/)
+    - [**2024-06-13** Data Sharing](https://www.ukrn.org/training/data-sharing-from-planning-to-publishing-13-jun/)
+    - [**2024-06-01 to 04** Introduction to Open
+      Software](https://www.ukrn.org/training/introduction-to-software-for-open-and-reproducible-research/)
+
+---
+
+For more forthcoming RSE training events, keep an eye on our
+[Training](https://rse.shef.ac.uk/training/) page and join our [mailing
+list](https://groups.google.com/a/sheffield.ac.uk/g/rse-group) to hear about new events.
+
+<!-- #### External Training -->
+
+<!--#### Research IT Training-->
+
+<!--Research IT courses have adopted a hybrid approach. The team will be providing their courses both online and in -->
+<!--person for the first time since March 2020. The team provides a place for beginners or advanced users to expand -->
+<!--their knowledge of HPC and different programming languages. The courses are part of the Doctoral Development -->
+<!--Programme. For more information please visit our training registration web page (via VPN): -->
+<!--[crs.shef.ac.uk](https://crs.shef.ac.uk).-->
+
+<!--If a course is "sold out" please join the wait list by signing up - we regularly email people to encourage those -->
+<!--that can no longer attend to cancel. Those on the wait list get early notification when the courses are run -->
+<!--again.-->
+
+<!-- ### Opportunities -->
+
+<!-- - [Description](https://www.elsewhere.ac.uk/): -->
+<!--   - More Details (optional) -->
+
+#### Jobs
+
+Check for advertised RSE and RSE-adjacent roles at the [RSE society's vacancies
+board](https://society-rse.org/careers/vacancies/).
+
+### Community
+
+#### Digital Research Practice Support Community
+
+The DRPS community is a group for people that support researchers in carrying out research in the digital age. Meetings
+are held monthly, with discussions around events, training and opportunities related to the field.
+
+You can join the google group
+[here](https://groups.google.com/u/1/a/sheffield.ac.uk/g/digital-research-practice-support-community-group/about) to
+stay informed.
+
+The next meeting is scheduled for 2pm on Wednesday 27th March 2024.
+
+#### LunchBytes
+
+[LunchBytes](https://rse.shef.ac.uk/community/lunch-bytes/) are short talks from the research community on research
+software, data, and infrastructure.
+
+##### LunchBytes needs YOU
+
+LunchBytes are organised by and for the research software community at The University of Sheffield. If you'd like to
+curate a session on a topic or present something, get in touch by emailing
+[lunchbytes-organisers-group@sheffield.ac.uk](mailto:lunchbytes-organisers-group@sheffield.ac.uk) or suggest topics
+[on the jamboard](https://jamboard.google.com/d/1-51cRf0pwZl8O10CnLeJGAqKcnbww-QGaYjszFK-H38/).
+
+### Support
+
+#### RSE support via the Centre for Machine Intelligence (CMI-RSE)
+
+Sheffield’s [Centre for Machine Intelligence (CMI)](https://www.sheffield.ac.uk/machine-intelligence) is funding 1 FTE
+of research engineering time, enabling RSE to provide AI/ML services without cost recovery. The CMI-RSE team primarily
+supports members of the University community by enabling, designing, implementing and refining AI streams in research
+projects.
+
+If you have a project in mind that would benefit from CMI-RSE involvement, please have a look at the
+[FAQ](https://rse.shef.ac.uk/collaboration/cmi-rse/) and complete the application form to register your interest and
+begin the conversation.
+
+#### Code Clinics
+
+Why not come to a [Code
+Clinic](https://docs.google.com/forms/d/e/1FAIpQLScGXS55qjU0D0Zcz-KHOVcNTahcr3YC3H0OpoKBo3lWXWED5A/viewform)? We're keen
+to help you.
+
+Code Clinics are fortnightly supported sessions run by the RSE team and IT Services’ [Research
+IT](https://www.sheffield.ac.uk/it-services/research) team. They are open to anyone at TUoS writing code for research to
+get help with programming problems and general advice on best practices.
+
+At each session, members of the RSE and/or Research IT teams will be available to review code, advise, troubleshoot, and
+suggest ways to improve your computational workflows.
+
+#### Research IT HPC Drop In
+
+HPC Drop-In sessions are providing assistance with HPC related user issues such as challenges in scaling an application
+from desktop to supercomputer. We are considering extending the number of our sessions to two or three weekly. These
+interactive sessions could provide a better interface with our users than our non-interactive ticketing system. These
+sessions are advertised on the [HPC mailing list](https://groups.google.com/u/1/a/sheffield.ac.uk/g/hpc).
+
+#### Research IT Consultations
+
+Alongside the HPC Drop-In sessions, Research IT are also running one to one consultations to solve in depth user
+specific problems. These consultations can be booked via our webpage. If you are interested please visit the following
+link: <https://students.sheffield.ac.uk/it-services/research>.
+
+## Sheffield RSE Team
+
+The Sheffield RSE Team aims to [collaborate](https://rse.shef.ac.uk/collaboration/) with you to help improve your
+research software. They can [provide dedicated staff](https://rse.shef.ac.uk/collaboration/provision/) to ensure that
+you can deliver excellent research software engineering on your research projects.
+
+## Research IT
+
+[Research IT](https://students.sheffield.ac.uk/it-services/research) directly supports research, both academic and
+commercial.  We provide large scale HPC systems, advice on everything from statistics to ML to data pipelines and
+training for both students and staff.
+
+Working with academics, our staff are embedded within research groups on both long and short term engagements.


### PR DESCRIPTION
Items from Slack `#newswire`.

Was unsure if UKRN Train the Trainer items should fit under **Training** or **External Events**, happy to move to the later.

Comments and feedback welcome, there are quite a few items with tight closing deadlines so keen to get this out as soon as possible.