### PR TITLE
Update community overview page

### DIFF
--- a/pages/community/index.md
+++ b/pages/community/index.md
@@ -34,4 +34,4 @@ The following links can provide more information on *national* initiatives.
 
 * [https://society-rse.org/](https://society-rse.org/) - the UK Society of Research Software Engineering
 * [http://www.software.ac.uk](https://www.software.ac.uk) - The Software Sustainability Institute
-* [https://twitter.com/ResearchSoftEng](https://twitter.com/ResearchSoftEng) - Official twitter feed of the UK RSE Community
+* [https://mastodon.social/@ResearchSoftEng](https://mastodon.social/@ResearchSoftEng) - Official mastodon feed of the UK RSE Community

--- a/pages/community/index.md
+++ b/pages/community/index.md
@@ -26,7 +26,6 @@ There are a number of other local initiatives that may be of interest to the res
 * The University of Sheffield's [Open Data Science Initiative](http://opendsi.cc)
 * The city of Sheffield has an [active R-user's group](https://sheffieldr.github.io/)
 * The [Sheffield Bioinformatics Core](http://sbc.shef.ac.uk) provides a Bioinformatics analysis and consulting service and runs specialised training courses
-* Physics and Astronomy [Programming Skills Sessions](https://www.sheffield.ac.uk/physics/news/programming-skills-sessions) organised by [SSI Fellow Becky Arnold](/blog/ssi-2018)
 
 ## National RSE Community
 
@@ -34,6 +33,5 @@ Research Software Engineering is a movement that's gaining momentum nationally a
 The following links can provide more information on *national* initiatives.
 
 * [https://society-rse.org/](https://society-rse.org/) - the UK Society of Research Software Engineering
-* [https://rse.ac.uk](https://rse.ac.uk) - The UK Community of Research Software Engineers
 * [http://www.software.ac.uk](https://www.software.ac.uk) - The Software Sustainability Institute
 * [https://twitter.com/ResearchSoftEng](https://twitter.com/ResearchSoftEng) - Official twitter feed of the UK RSE Community


### PR DESCRIPTION
I found a couple of dead links while mooching about the RSE site.
Also swapped the RSE Soc twitter link to their mastodon feed. The former needs you to log-in/sign-up to access the page, while the latter can be read by anyone. 