### PR TITLE
Remove trailing dash from event item if no times are supplied

### DIFF
--- a/_includes/events_list_item.html
+++ b/_includes/events_list_item.html
@@ -16,7 +16,7 @@
 
         <div class="media mb-1">
             <img class="align-self-center mr-2" src="/assets/images/icons/icons8-watch-50.png" width="20" alt="Start time"/>
-            <div class="media-body"><strong>{{ event.date | date: "%-d %B %Y" }}  {% if event.end-date %} to {{ event.end-date | date: "%-d %B %Y" }}{% endif %} - {{ event.from}}{% if event.to %}-{{event.to}}{% endif %}</strong></div>
+            <div class="media-body"><strong>{{ event.date | date: "%-d %B %Y" }}  {% if event.end-date %} to {{ event.end-date | date: "%-d %B %Y" }}{% endif %}{% if event.from %} - {{ event.from}}{% if event.to %}-{{event.to}}{% endif %}{% endif %}</strong></div>
         </div>
         {% if event.location %}
         <div class="media mb-1">


### PR DESCRIPTION
Closes #478. 

Adds a check to see if a "from" time has been added to the event, if not, the dash is not rendered.