### PR TITLE
Home page improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,10 @@ twitter:
   card: summary
 logo: /assets/images/logo/rse-logoonly-stroke-blackborder.png
 
+# Adjust number of blog entries and events on home page
+blog_limit: 3
+event_limit: 4
+
 future: true # required for collections with a date field, where future events are desired.
 collections:
   events:

--- a/_includes/events_list_top10.html
+++ b/_includes/events_list_top10.html
@@ -1,7 +1,7 @@
 {% assign events = (site.events | sort: 'date' | reverse) %}
 <div class="event-listing event-upcoming-previous event-insert-header">
   {% if events and events.size > 0 %}
-  {% for event in events limit:10 %}
+  {% for event in events limit:include.post_limit %}
   {% if include.category %}
   {% assign categories = include.category | split: "," %}
   {% for category in categories %}

--- a/_includes/post_list_prev10.html
+++ b/_includes/post_list_prev10.html
@@ -1,3 +1,3 @@
-{% for post in site.posts limit:10 %}
+{% for post in site.posts limit:include.post_limit %}
     {% include post_list_item.html post=post %}
 {% endfor %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,14 @@
 layout: default
 ---
 
+{% capture blog_post_limit %}
+{{ site.blog_limit | default: 10 }}
+{% endcapture %}
+
+{% capture event_limit %}
+{{ site.event_limit | default: 10 }}
+{% endcapture %}
+
 <!-- ******PROMO****** -->
 <section id="promo" class="promo section offset-header">
     <div class="container text-center">
@@ -72,7 +80,7 @@ layout: default
 
                 <h2><a href="/blog/">Blog</a></h2>
                 <br />
-                {% include post_list_prev10.html %}
+                {% include post_list_prev10.html post_limit=blog_post_limit %}
 
                 <p>
                     <a href="/blog/">All blog articles >></a>
@@ -81,7 +89,7 @@ layout: default
             </div>
 
             <div class="col-md-6">
-                {% include events_list_top10.html %}
+                {% include events_list_top10.html post_limit=event_limit %}
 
                 <p>
                     <a href="/events/">All of our upcoming and previous events >></a>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -77,6 +77,10 @@ a {
     text-decoration: underline;
 }
 
+.contact-inner a:hover {
+    color: var(--uos-deep-violet-70);
+}
+
 .contact-inner h2 {
     color: var(--white) !important;
 }


### PR DESCRIPTION
* Enable configurable number of blog and event items on home page
* Override theme hover colour for contact links which was unreadable against custom background setting

Addresses a point raised in #556: 
> Reduce the number of blog entries and past events shown on the homepage, to promote the contact us section (content could also be improved)
