### PR TITLE
Switch pa11y to @aarongoldenthal/pa11y-ci

### DIFF
--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -34,7 +34,7 @@ jobs:
 
       # Install pa11y requirements
       - name: Install pa11y-ci
-        run: npm install -g @aarongoldenthal/pa11y-ci
+        run: npm install -g pa11y-ci
 
       # Check site accesibility
       - name: Serve site and test with pa11y

--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -34,7 +34,7 @@ jobs:
 
       # Install pa11y requirements
       - name: Install pa11y-ci
-        run: npm install -g pa11y-ci
+        run: npm install -g @aarongoldenthal/pa11y-ci
 
       # Check site accesibility
       - name: Serve site and test with pa11y

--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Building site and running pa11y-ci tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       # Clone the repository and checkout into the relevant branch


### PR DESCRIPTION
CI was encountering errors when launching chromium via puppeteer, with pa11y 3.1 using quite old versions. 

Switching to a fork or pa11y with newer dependency versions in an attempt to resolve the CI issues.

This will depend on the 3rd party fork also being maintained going forwards