### PR TITLE
Remove jade2 link from contact, adjust jade2.md

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -10,7 +10,7 @@
             </p>
 
             <p>
-                Information and access to <a href="https://docs.hpc.shef.ac.uk/en/latest/other-uk-hpc-resources/jade2.html">JADE II</a> and <a href="https://docs.hpc.shef.ac.uk/en/latest/other-uk-hpc-resources/bede.html">Bede</a>.                
+                Information and access to <a href="https://docs.hpc.shef.ac.uk/en/latest/other-uk-hpc-resources/bede.html">Bede</a>.                
             </p>
 
             <p>

--- a/_project_descriptions/jade2.md
+++ b/_project_descriptions/jade2.md
@@ -3,8 +3,7 @@ key: jade2
 ---
 
 JADE II was a GPU-based, deep Learning focused, Tier-2 HPC service associated with 19 academic partners including Sheffield.
-JADE II ceased to accept jobs on 2024-11-15 and
-will be decommissioned on 2025-01-06.
+JADE II was decommissioned on 2025-01-06.
 JADE II was the successor of the [JADE](http://www.jade.ac.uk/) system, which was decommissioned in 2021.
 
 RSES has been a local institutional contact and has been involved in


### PR DESCRIPTION
Removes a link to JADE 2 from our footer / contact section. 

Updates jade2.md to mark it as now decomissioned (rather than being decmoissioned in the future)