### PR TITLE
pages: call for proposals 2025

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,19 +3,21 @@
     - title: Why work with us?
       url: /collaboration/
     - title: How to work with us
-      url: /collaboration/provision/ 
+      url: /collaboration/provision/
     - title: Collaboration Guide
-      url: /collaboration/guide/ 
+      url: /collaboration/guide/
     - title: What We Do
-      url: /collaboration/activities        
+      url: /collaboration/activities
     - title: Costing RSE time
       url: /collaboration/costing
     - title: Projects
       url: /collaboration/projects
     - title: CMI-RSE Projects
-      url: /collaboration/cmi-rse         
+      url: /collaboration/cmi-rse
+    # - title: Call for proposals 2025
+    #   url: /collaboration/RSEtime/2025
     - title: Call for proposals 2024
-      url: /collaboration/RSEtime_call2024
+      url: /collaboration/RSEtime/2024
     - title: Testimonials
       url: /collaboration/testimonials
 - title: "Training & Resources"

--- a/pages/collaboration/RSEtime/2024/call.md
+++ b/pages/collaboration/RSEtime/2024/call.md
@@ -1,6 +1,6 @@
 ---
-title: Call for Proposal - RSE collaboration [Closed]
-permalink: /collaboration/RSEtime_call2024/
+title: Call for Proposal - RSE collaboration 2024 [Closed]
+permalink: /collaboration/RSEtime/2024/
 slug: index
 type: text
 ---
@@ -10,13 +10,14 @@ type: text
 ### Rationale
 
 #### Introduction
-The University of Sheffield recognizes the critical role that Research Software Engineers (RSEs) play in advancing scientific research. The University of Sheffield Research Software Engineering (RSE) team was founded in 2016 by two EPSRC RSE fellows to develop research software and collaborate with academics/researchers developing research software. The team has since grown to 11 members and has engaged with all faculties at the University.  We have worked with research teams on small internally funded projects but also with large international consortiums and industry. Areas of expertise within the group include: code optimisation and performance, reproducibility and embedding good software engineering practice within a project or team, developing/maintaining infrastructure, data management, developing computational workflows, GPU computing and Deep Learning, data science/visualisation, High Performance Computing using local/national/international/cloud systems, general software development, software/hardware interface, development of impact case studies, consultancy, training and education delivery and support. 
+
+The University of Sheffield recognizes the critical role that Research Software Engineers (RSEs) play in advancing scientific research. The University of Sheffield Research Software Engineering (RSE) team was founded in 2016 by two EPSRC RSE fellows to develop research software and collaborate with academics/researchers developing research software. The team has since grown to 11 members and has engaged with all faculties at the University.  We have worked with research teams on small internally funded projects but also with large international consortiums and industry. Areas of expertise within the group include: code optimisation and performance, reproducibility and embedding good software engineering practice within a project or team, developing/maintaining infrastructure, data management, developing computational workflows, GPU computing and Deep Learning, data science/visualisation, High Performance Computing using local/national/international/cloud systems, general software development, software/hardware interface, development of impact case studies, consultancy, training and education delivery and support.
 
 To support the *One University* vision and the University research community we are pleased to announce the **2024 RSE collaboration call for proposals**. This initiative aims to facilitate access to RSE expertise for researchers who require assistance with software development, optimization, or other computational challenges.
 
 #### Objective
-The objective of this call is to offer dedicated RSE collaboration to researchers who may lack the resources or expertise to effectively develop and maintain research software. By providing free access to RSE expertise, we aim to enhance the quality, reliability, and impact of research projects across diverse disciplines.
 
+The objective of this call is to offer dedicated RSE collaboration to researchers who may lack the resources or expertise to effectively develop and maintain research software. By providing free access to RSE expertise, we aim to enhance the quality, reliability, and impact of research projects across diverse disciplines.
 
 #### Eligibility
 
@@ -25,12 +26,12 @@ The objective of this call is to offer dedicated RSE collaboration to researcher
 - Preference may be given to projects with potential high impact or those addressing pressing scientific challenges.
 
 #### Funding and support
+
 For this first call, the team will select two projects.**Selected proposals will receive 6 months @ 45-50% FTE of RSE support**. The start date will be decided by the RSE team based on the project timeline and RSEs availability. The duration of the project will not exceed 6 months but might be shortened with a higher FTE fraction (e.g. 3 months @ 100%). In addition, the collaboration will be continuous and can not be split into multiple shorter, disjointed periods of time.
 
-
 ### Application guidelines
-An application template for this call has been prepared and is available [here](https://docs.google.com/document/d/1yzqS8gS-iCQ4HgM3dBcYEfYsS9E1Zm28CguZrTMl22M/edit?usp=sharing). We kindly request applicants to use this template for the application. This is a locked file so please make a copy to be able to complete it. We give more details about each section below.
 
+An application template for this call has been prepared and is available [here](https://docs.google.com/document/d/1yzqS8gS-iCQ4HgM3dBcYEfYsS9E1Zm28CguZrTMl22M/edit?usp=sharing). We kindly request applicants to use this template for the application. This is a locked file so please make a copy to be able to complete it. We give more details about each section below.
 
 - **Abstract [max 600 words]:** Provide a brief description of the research project, its objectives and the role of software or computation methods in achieving these objectives. As reviewers might not be expert in your field, please make sure that your abstract is accessible to the panel.
 
@@ -63,6 +64,7 @@ The criteria for the selection will be the following:
 Selected projects will be advertised on our website (displaying a short abstract of the project).
 
 ### Important dates
+
 - Deadline for proposal submission: June 28th
 - Notification of Decision: July 22th
 - Earliest start of project: September 1st
@@ -70,6 +72,6 @@ Selected projects will be advertised on our website (displaying a short abstract
 
 **Important Note:** While the P.I. is requested to provide an ideal starting date, the final starting date might be different. Availability of team members depends on other projects and we will make our best to accommodate the requested starting date. We will therefore ask the P.I.s to understand that if their project is selected, the starting date might be different from what they have requested.
 
-
 ### Contact information
+
 For inquiries or assistance with the proposal submission process, please contact Neil Shephard ([n.shephard@sheffield.ac.uk](mailto:n.shephard@sheffield.ac.uk), Chair of the selection Panel) and/or Romain Thomas, ([romain.thomas@sheffield.ac.uk](mailto:romain.thomas@sheffield.ac.uk), Head of the RSE group).

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -9,7 +9,7 @@ type: text
 
 #### Introduction
 
-The University of Sheffield recognizes the critical role that Research Software Engineers (RSEs) play in advancing
+The University of Sheffield recognises the critical role that Research Software Engineers (RSEs) play in advancing
 scientific research. The University of Sheffield Research Software Engineering (RSE) team was founded in 2016 by two
 EPSRC RSE fellows to develop research software and collaborate with academics/researchers developing research
 software. The team has since grown to 11 members and has engaged with all faculties at the University.  We have worked

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -12,18 +12,24 @@ type: text
 The University of Sheffield recognises the critical role that Research Software Engineers (RSEs) play in advancing
 scientific research. The University of Sheffield Research Software Engineering (RSE) team was founded in 2016 by two
 EPSRC RSE fellows to develop research software and collaborate with academics/researchers developing research
-software. The team has since grown to 11 members and has engaged with all faculties at the University.  We have worked
+software. The team has since grown to 13 members and has engaged with all faculties at the University.  We have worked
 with research teams on small internally funded projects but also with large international consortiums and
-industry. Areas of expertise within the group include: code optimisation and performance, reproducibility and embedding
-good software engineering practice within a project or team, developing/maintaining infrastructure, data management,
-developing computational workflows, GPU computing and Deep Learning, data science/visualisation, High Performance
-Computing using cloud and local/national/international systems, general software development, software/hardware interface,
-development of impact case studies, consultancy, training and education delivery and support.
+industry. Areas of expertise within the group include:
+
+- code optimisation and performance
+- reproducibility and embedding good software engineering practice within a project or team
+- developing computational workflows
+- GPU and High Performance Computing
+- Artificial intelligence/Machine Learning
+- data science/visualisation
+- general software development
+- software/hardware interface
 
 To support the *One University* vision and the University research community we are pleased to announce for the second
 consecutive year the **2025 RSE collaboration call for proposals**. This initiative aims to facilitate access to RSE
 expertise for researchers who require assistance with software development, optimization, or other computational
-challenges. The 2024 call was very popular and we received 26 submissions.
+challenges. The 2024 call was very popular and we received 26 submissions, you can read a summary of last years
+proposals on our [blog](https://rse.shef.ac.uk/blog/2024-09-24-funded-proposals/).
 
 #### Objective
 

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -1,0 +1,126 @@
+---
+title: Call for Proposal - RSE collaboration 2025
+permalink: /collaboration/RSEtime/2025/
+slug: index
+type: text
+---
+
+### Rationale
+
+#### Introduction
+
+The University of Sheffield recognizes the critical role that Research Software Engineers (RSEs) play in advancing
+scientific research. The University of Sheffield Research Software Engineering (RSE) team was founded in 2016 by two
+EPSRC RSE fellows to develop research software and collaborate with academics/researchers developing research
+software. The team has since grown to 11 members and has engaged with all faculties at the University.  We have worked
+with research teams on small internally funded projects but also with large international consortiums and
+industry. Areas of expertise within the group include: code optimisation and performance, reproducibility and embedding
+good software engineering practice within a project or team, developing/maintaining infrastructure, data management,
+developing computational workflows, GPU computing and Deep Learning, data science/visualisation, High Performance
+Computing using local/national/international/cloud systems, general software development, software/hardware interface,
+development of impact case studies, consultancy, training and education delivery and support.
+
+To support the *One University* vision and the University research community we are pleased to announce for the second
+consecutive year the **2025 RSE collaboration call for proposals**. This initiative aims to facilitate access to RSE
+expertise for researchers who require assistance with software development, optimization, or other computational
+challenges. The 2024 call was very popular and we received XX submissions.
+
+#### Objective
+
+The objective of this call is to offer dedicated RSE collaboration to researchers who may lack the resources or
+expertise to effectively develop and maintain research software. By providing free access to RSE expertise, we aim to
+enhance the quality, reliability, and impact of research projects across diverse disciplines.
+
+#### Eligibility
+
+- Any research active staff, including PDRAs, and PhD students, affiliated to the University of Sheffield can apply to
+  this call.
+- Projects must involve significant software development that would benefit from RSE expertise.
+- Preference may be given to projects with potential high impact or those addressing pressing scientific challenges.
+
+#### Funding and support
+
+For this first call, the team will select two projects. **Selected proposals will receive 6 months @ 45-50% FTE of RSE
+support**. The start date will be decided by the RSE team based on the project timeline and RSEs availability. The
+duration of the project will not exceed 6 months but might be shortened with a higher FTE fraction (e.g. 3 months @
+100%). In addition, the collaboration will be continuous and can not be split into multiple shorter, disjointed periods
+of time.
+
+### Application guidelines
+
+An application template for this call has been prepared and is available
+[here](https://docs.google.com/document/d/1yzqS8gS-iCQ4HgM3dBcYEfYsS9E1Zm28CguZrTMl22M/edit?usp=sharing). This is a
+locked file so please make a copy and use it to draft your proposal. When you are ready to submit please use the
+[form](https://forms.gle/UGFz35xiXXx9GtEDA). Further details about each section are given below.
+
+- **Abstract [max 600 words]:** Provide a brief description of the research project, its objectives and the role of
+  software or computation methods in achieving these objectives. As reviewers might not be expert in your field, please
+  make sure that your abstract is accessible to the panel.
+
+- **RSE support objectives [max 600 words]:** Outline the specific areas where RSE expertise is needed, such as software
+  development, optimisation, debugging, use of HPC, etc… We remind you that, if selected, your project will receive 6
+  months half time. You will have to take into account project onboarding at the beginning of the collaboration and
+  offboarding the project where we will handover the work done back to you.
+
+- **Expected outcome [max 300 words]:** What does a successful collaboration look like to you? Describe the anticipated
+  outcomes resulting from the contribution of RSE.
+
+- **Project risks [max 200 words]:** What issues may cause the collaboration to be unsuccessful? Briefly describe the
+  potential risks to the project. (A common example: lack of data or no access to sensitive data).
+
+- **Impact statement [max 200 words]:** Explain how access to free RSE time would benefit the project and contribute to
+  its success or broader research goals.
+
+- **Existing material [max 200 words]:** Briefly explain what existing material you already have: Data, Software,
+  Documentation…
+
+- **Preferred timeline:** what would be the ideal time distribution of the RSE.
+
+**The application shall be sent to the chair of the panel N. Shephard (see below for contact information) with subject
+'Application for RSE call 2025', as PDF no later than the 28th of June at 5pm.**
+
+### Review and selection process
+
+The panel reviewing the projects will consist of members from the Research Software Engineering (RSE) team and Data
+Analytics Service (DAS). The panel will gather in July where a shortlist of six proposals will be invited for a short interview.
+
+The criteria for the selection will be the following:
+
+- **Fit:** Request fits the objective of the call.
+- **Skills:** Does the RSE team have the required skills? Are these skills available for the duration of the project?
+- **Impact:** Potential Impact of the RSE work [For the project, and wider for the community.]
+- **Practicality:** How easy will it be for the RSE to join the project?
+- **Resource efficiency:** Is the work requested achievable in the offered time?
+
+Selected projects will be advertised on our website (displaying a short abstract of the project).
+
+#### Interview
+
+The Primary Investigator, and at their discretion their co-investigators, of shortlised proposals will be invited to
+attend a short interview with three members of staff from the RSE and DAS. The purpose of the interview will be to
+
+- share with the panel the current state of the software, demonstrate how it is currently used.
+- discuss the expected goals of RSE involvement and the impact it will have on the software and its users, both within
+  the research group and beyond.
+- consider any risks associated with undertaking the work.
+
+### Important dates
+
+- Call Opens: May 26th 2025
+- Deadline for proposal submission: June 28th 2025
+- Shortlisting for interview: July 23rd 2025
+- Interview: July 27th 2025
+- Notification of Decision: July 30th 2025
+- Earliest start of project: September 1st 2025
+- Latest start of project: February 3rd 2026
+
+**Important Note:** While the P.I. is requested to provide an ideal starting date, the final starting date might be
+different. Availability of team members depends on other projects and we will make our best to accommodate the requested
+starting date. We will therefore ask the P.I.s to understand that if their project is selected, the starting date might
+be different from what they have requested.
+
+### Contact information
+
+For inquiries or assistance with the proposal submission process, please contact Neil Shephard
+([n.shephard@sheffield.ac.uk](mailto:n.shephard@sheffield.ac.uk), Chair of the selection Panel) and/or Romain Thomas,
+([romain.thomas@sheffield.ac.uk](mailto:romain.thomas@sheffield.ac.uk), Head of the RSE group).

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -23,7 +23,7 @@ development of impact case studies, consultancy, training and education delivery
 To support the *One University* vision and the University research community we are pleased to announce for the second
 consecutive year the **2025 RSE collaboration call for proposals**. This initiative aims to facilitate access to RSE
 expertise for researchers who require assistance with software development, optimization, or other computational
-challenges. The 2024 call was very popular and we received XX submissions.
+challenges. The 2024 call was very popular and we received 26 submissions.
 
 #### Objective
 

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -76,8 +76,8 @@ locked file so please make a copy and use it to draft your proposal. When you ar
 
 - **Preferred timeline:** what would be the ideal time distribution of the RSE.
 
-**The application shall be sent to the chair of the panel N. Shephard (see below for contact information) with subject
-'Application for RSE call 2025', as PDF no later than the 28th of June at 5pm.**
+**The application should be submitted via the [form](https://forms.gle/UGFz35xiXXx9GtEDA) no later than the 28th June
+17:00 BST.**
 
 ### Review and selection process
 

--- a/pages/collaboration/RSEtime/2025/call.md
+++ b/pages/collaboration/RSEtime/2025/call.md
@@ -17,7 +17,7 @@ with research teams on small internally funded projects but also with large inte
 industry. Areas of expertise within the group include: code optimisation and performance, reproducibility and embedding
 good software engineering practice within a project or team, developing/maintaining infrastructure, data management,
 developing computational workflows, GPU computing and Deep Learning, data science/visualisation, High Performance
-Computing using local/national/international/cloud systems, general software development, software/hardware interface,
+Computing using cloud and local/national/international systems, general software development, software/hardware interface,
 development of impact case studies, consultancy, training and education delivery and support.
 
 To support the *One University* vision and the University research community we are pleased to announce for the second


### PR DESCRIPTION
Closes #897

Moves the 2024 page to a new nested location and adds a 2025 page.

The 2025 page is commented out of `_data/navigation.yml` and so _doesn't_ appear in the rendered pages. To view navigate to the 2024 page `Ctrl + l` to get to the navigation bar and change `/2024/` to `/2025/` and hit `Ret`.

When page is ready to go live this will be uncommented and will also require adding to the front-page. Will address in a separate issue/pull-request.