### PR TITLE
navigation: 2024 > 2025 call for proposals

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -14,10 +14,8 @@
       url: /collaboration/projects
     - title: CMI-RSE Projects
       url: /collaboration/cmi-rse
-    # - title: Call for proposals 2025
-    #   url: /collaboration/RSEtime/2025
-    - title: Call for proposals 2024
-      url: /collaboration/RSEtime/2024
+    - title: Call for proposals 2025
+      url: /collaboration/RSEtime/2025
     - title: Testimonials
       url: /collaboration/testimonials
 - title: "Training & Resources"


### PR DESCRIPTION
Whilst I included a new page and adjusted the location of 2024 link in `_data/navigation.yaml` to point to the new
location I forgot to change the navigation to point to the current 2025 call which opened today before merging the PR this morning.