### PR TITLE
remove extra_links from nshephard profile

### DIFF
--- a/_people/neil-shephard.md
+++ b/_people/neil-shephard.md
@@ -6,10 +6,10 @@ published: true
 othernames: Neil
 surname: Shephard
 role: Research Software Engineer
-image:
+image: https://cdn.sheffield.ac.uk/sites/default/files/styles/profile_modal/public/2023-07/CS_Headshots_013.jpg?h=4a8cf41e&itok=OH3mXgtg
 links:
     - url: mailto:n.shephard@sheffield.ac.uk
-      icon: 
+      icon:
         class: "fas fa-envelope"
         a11y: "Email"
       label: n.shephard@sheffield.ac.uk
@@ -29,11 +29,6 @@ extra_links:
         class: "fas fa-link"
         a11y: "Link"
       label: "Blog"
-    - url: "https://wiki.nshephard.dev/"
-      icon:
-        class: "fas fa-link"
-        a11y: "Link"
-      label: "Web"
     - url: "https://fosstodon.org/@nshephard"
       icon:
         class: "fas fa-link"


### PR DESCRIPTION
The link to @ns-rse wiki is unnecessary, its not updated and new content from him is best found on the blog which is
already linked.