### PR TITLE
Use a liquid include as a function for re-use of ', and' joining of lists

### DIFF
--- a/_includes/join_list_commas_and.html
+++ b/_includes/join_list_commas_and.html
@@ -1,0 +1,23 @@
+{% comment %}
+include as a function, which given a parameter `list`, will return the list joined with `,` but (also) using `and` between the last 2 elements.
+
+Uses include.list[0] to determine if the input is a list (should be falsey for a string or empty list) allowing individual strings to be passed in too.
+
+usage (without the extra spaces): 
+
+{ % include join_list_commas_and.html list=foo % }
+
+{% endcomment %}
+{% if include.list[0] %}
+    {% if include.list.size > 2 %}
+        {% assign last_item = include.list | last %}
+        {% assign new_last = "and " | append: last_item %}
+        {{ include.list | join: ", " | replace: last_item, new_last}}
+    {% elsif include.list.size == 2 %}
+        {{ include.list | join: " and "}}
+    {% elsif include.list.size == 1 %}
+        {{ include.list }}
+    {% endif %}
+{% else %}
+    {{ include.list }}
+{% endif %}

--- a/pages/collaboration/projects/projects.md
+++ b/pages/collaboration/projects/projects.md
@@ -73,25 +73,15 @@ The Research Software Engineering team at Sheffield has worked on projects invol
     {% if project.include %}
     <div class="project">
       <h3>{{ project.title }}</h3>
-      <h4>{{ project.pi_name|join: ", " }}</h4>
+      <h4>{% include join_list_commas_and.html list=project.pi_name %}</h4>
       <h5>{{ project.dept}}</h5>
       <hr/>
       <b>{{ project.start_date | date_to_string }} - {{ project.end_date | date_to_string }}</b>
       <br/>
-      RSE{% if project.rses.size > 1 %}(s){% endif %}: <em> 
-      {%- if project.rses.size > 2 %}
-      {% assign last_item = project.rses | last %}
-      {% assign new_last = "and "| append: last_item %}
-      {{ project.rses | join: ", " | replace: last_item, new_last}}
-      {%- elsif project.rses.size == 2 -%}
-      {{ project.rses | join: " and "}}
-      {%- elsif project.rses.size == 1 -%}
-      {{ project.rses}}
-      {%- endif -%}
-      </em>
+      RSE{% if project.rses.size > 1 %}(s){% endif %}: <em>{% include join_list_commas_and.html list=project.rses %}</em>
       <br/>
       {%- if project.collaborators.size > 0 -%}
-      Collaborator(s): <em>{{ project.collaborators | join: ", " }}</em>
+      Collaborator(s): <em>{% include join_list_commas_and.html list=project.collaborators %}</em>
       {%- endif -%}
       <div class="proj-content {% if project.image == blank %}no-image{% endif %}">
         {% if project.image %}


### PR DESCRIPTION
Adds a liquid include `join_list_comma_and.html` which can be used as a function to use-use logic joining a list into a string and emitting into the page.

This then applies the same joining logic to 3 lists in the projects page redesign.