### PR TITLE
December 2025 Newsletter

### DIFF
--- a/_newsletters/2025-12-05-newsletter.md
+++ b/_newsletters/2025-12-05-newsletter.md
@@ -1,0 +1,210 @@
+---
+layout: post
+title: December 2025 Newsletter
+editor: Robert Chisholm
+slug: 2025-12-11-newsletter
+date: 2025-12-11T12:00:00Z+0100
+tags:
+category:
+link:
+description:
+type: text
+---
+
+## The University of Sheffield Research Software Engineering Community Newsletter December 2025
+
+Welcome to the December 2025 newsletter for the research software community at The University of Sheffield, featuring
+news, opportunities, events and training for you.
+
+---
+
+## News
+
+- At the Sheffield RSE team, we've recently refreshed parts of our website:
+  - All-new [projects page](https://rse.shef.ac.uk/collaboration/projects/), highlighting the diverse range of projects we've collaborated on.
+  - Redesigned [team page](https://rse.shef.ac.uk/contact/team/), now including photos of most of our team's members.
+- Society RSE has began their consultation process for updating their ethical sponsorship policy. The first survey has closed, and the second for [arguments against each of the proposed areas to be submit](https://docs.google.com/forms/d/e/1FAIpQLSfXcIoUTJnEtA53rgVJOIQ-BbhEIHu6zulCVR1RS6JMfhAQ5g/viewform?usp=publish-editor), closes 29th December. More information can be found on [Society RSE's website](https://society-rse.org/about/policies/avoidance-criteria-for-ethical-sponsorship-policy/).
+- Version 1.3.0 of the [Research Software Quality Toolkit ({RSQ}Kit)](https://everse.software/RSQKit/) has released.
+
+---
+
+## Events
+
+### RSE lunchtime seminars
+
+Members of Sheffield RSE will be hosting a new small seminar series in the new year, with **catered lunches**!
+
+The first lunchtime seminar "Introduction to Software Performance Optimisation", is aimed at any researchers who'd like to be introduced to why they can benefit from reviewing the performance of their code and how easy it can be.
+
+The first seminar has now been scheduled for **Thursday 2026-02-26 from 1-2pm**.
+
+You can now sign up on [MyDevelopment](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/13505955-32a6-464c-8d6a-2742ba2e8f4d?isOnePlayer=true) to get notified first when registration for this seminar is available .
+
+
+### FAIR^2 for Research Software Training
+
+The [FAIR^2 for Research Software](https://fair2-for-research-software.github.io) training continues in the new year with the following courses which are bookable via the myDevelopment links below (you need to be signed into MUSE to access these).
+
+- 2026-02-04/05 [Git, GitHub and GitKraken](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/d4d09f67-097b-4451-8ddb-86cb90636c06?isOnePlayer=true)
+- 2026-02-18 [Reproducible software environments](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/e30c407d-c97d-44a0-b3fd-4e87f95c4789?isOnePlayer=true)
+- 2026-03-02/03 [Git With It](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/6197989b-bef2-4352-a14b-02c4f45bbca6?isOnePlayer=true)
+- 2026-03-09 [Software testing](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/460c53c5-40e4-4c97-ab4f-144213544026?isOnePlayer=true)
+- 2026-03-19 [Packaging](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/0cbafddd-4c31-4e8a-bce6-a12e895a4acf?isOnePlayer=true)
+- 2026-04-29 [Documentation](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/7c81f9fd-656f-4ae9-ba48-bc83afe81cc2?isOnePlayer=true)
+- 2026-05-11 [Publishing](https://mydevelopment.csod.com/ui/lms-learning-details/app/event/9fa9503c-81a1-4667-af7b-14d62a4b82bc?isOnePlayer=true)
+
+
+### Upcoming External Events
+
+- [Integrating research software into open scholarly infrastructures: results of the SoFAIR project](https://forms.gle/R3Ggs67h1pJqrg889) Free webinar as part of the [SoFair project](https://sofair.org/), on Thursday **2025-12-11** 3PM, registration is required.
+- [DisCouRSE Focus Group: Team Culture and Leadership in dRTP contexts](https://www.software.ac.uk/news/discourse-focus-group-team-culture-and-leadership-drtp-contexts), on Monday **2026-01-19** at King's College London
+- [N8 Online Research Technical Professional Recruitment and Diversity
+  Sandpit](https://n8cir.org.uk/events/drtp-recruitment-and-diversity-sandpit/) Tuesday **2026-01-20** Join an engaging
+  and forward-thinking event that brings together individuals involved in or interested in Recruitment and its
+  connection to the diverse skills and backgrounds of dRTPs across the N8CIR. Whether you're leading recruitment efforts
+  or have experienced its impact firsthand, your perspectives are vital. Over the course of four dynamic hours, we’ll
+  delve into the current recruitment landscape, share effective strategies, and uncover common challenges. Through
+  interactive breakout sessions and insightful panel discussions, we’ll collaboratively shape the future direction of
+  dRTP recruitment within our community. Expect rich conversations, practical takeaways, and a shared articulation of
+  needs that reflects the values and priorities of the N8 research network. Come along to connect, contribute, and
+  co-create the future of dRTPs.
+- [Software Sustainability Institute Collaboration Workshop 2026 Proposal
+  Submission](https://www.software.ac.uk/news/take-stage-cw26-submit-your-proposals-now) This hybrid event which takes
+  place [2026-04-28 to 2026-04-30](https://www.software.ac.uk/workshop/collaborations-workshop-2026-cw26) in Belfast is
+  now taking submissions for Mini-workshops, demonstrations and lightning talks. Deadline for applications **2026-01-16
+  23:59**.
+- [EVERSE Community Engagement Event](https://everse.software/news/2025-10-31-community-engagement/) Online & at CERN in Switzerland **2026-02-05**.
+- [rainbowR's 1st conference](https://conference.rainbowr.org/) will be hosted online **2026-02-25** to **2026-02-26**.
+  - Call for submissions has now closed, but free registration will open soon.
+- N8 DRI Retreat 2026 in Manchester **2026-03-23** to **2026-03-27**. [Register your interest now](https://www.qualtrics.manchester.ac.uk/jfe/form/SV_3wIjTxcyzObjiMm).
+- [Durham HPC days 2026](https://hpc-days.github.io/Durham-HPC-Days-2026/) will take place in Durham from **2026-06-15** to **2026-06-19**. - Registration (costing £50) for this week-long event is now open.
+  - The [call for sessions](https://hpc-days.github.io/Durham-HPC-Days-2026/call-for-sessions/) is now open (Deadline Saturday **2026-01-31**)
+
+---
+
+## Articles, Blogs, Papers & Podcasts
+
+### Articles & Blogs
+
+- [Research Technical Professional Career Paths in UCL’s Advanced Research Computing Centre](https://www.software.ac.uk/blog/research-technical-professional-career-paths-ucls-advanced-research-computing-centre)
+- [Stop treating code like an afterthought](https://www.nature.com/articles/d41586-025-03196-0): record, share and value it
+- [Is AI After My Job? Navigating the Future of Research Software Engineering](https://www.software.ac.uk/blog/ai-after-my-job-navigating-future-research-software-engineering)
+- [Navigating Careers in Digital Research: How the DIRECT Framework Can Help](https://www.software.ac.uk/blog/navigating-careers-digital-research-how-direct-framework-can-help)
+- The Journal of Open Source Software (JOSS) has announced their [interim position on AI-enabled software](https://joss.readthedocs.io/en/latest/submitting.html#interim-position-on-ai-enabled-software).
+
+
+<!-- #### RSE Sheffield Blog Updates -->
+
+### Papers
+
+- [PRE-PRINT][Environmental Impact of CI/CD Pipelines](https://arxiv.org/abs/2510.26413): Strengthening the case for capturing errors as early as possible in development pipelines and not waiting for CI/CD to catch them.
+- [Engineering Open by Design into Research Infrastructures](https://riojournal.com/article/163817/)
+- [PRE-PRINT][Staying or Leaving? How Job Satisfaction, Embeddedness and Antecedents Predict Turnover Intentions of Software Professionals](https://arxiv.org/abs/2512.00869)
+
+### Podcasts & Videos
+
+- Recordings and slides from DiRAC's HPC AI conference in October can now be found on [their website](https://dirac.ac.uk/hpc-ai-advisory-council-7th-annual-uk-conference/).
+  - Including [
+Reasonable Performance Computing SIG](https://www.youtube.com/watch?v=s-Ui4bh39Zc) presented by Robert Chisholm from the Sheffield RSE team.
+
+---
+
+## Opportunities
+
+- [BioFair Pathfinder Projects](https://biofair.uk/pathfinder-projects/) Offering researchers and research technical
+  professionals the opportunity to tackle real-world barriers to making life sciences data and workflows FAIR and
+  AI-ready. A total of £800,000 is available with individual awards being a maximum of £100,000. Applications close
+  **2025-12-15 16:00**.
+- [Sandpit: Reservoir Computing for national security and defence](https://www.ukri.org/opportunity/sandpit-reservoir-computing-for-national-security-and-defence/) Apply to attend a [four-day interactive interdisciplinary sandpit](https://www.ukri.org/councils/epsrc/guidance-for-applicants/types-of-funding-we-offer/transformative-research/sandpits/) to develop projects on reservoir computing for national security and defence applications. Participants selected to attend must do so for all online and in-person days.
+- [AIRR compute opportunity: AI for Science](https://www.ukri.org/opportunity/airr-compute-opportunity-ai-for-science/) Apply for between 200,000 and 1,000,000 graphics processing unit (GPU) hours on the Isambard-AI and Dawn supercomputers for artificial intelligence (AI) related research and development projects. Closes **2025-12-21**.
+- [Isambard-AI and Dawn AIRR supercomputers: Innovator route](https://www.ukri.org/opportunity/isambard-ai-and-dawn-airr-supercomputers-innovator-route/) Apply for up to 150,000 graphics processing unit hours on the Isambard-AI and Dawn supercomputers for artificial intelligence (AI) related research and development projects. Closes **2026-01-16**.
+- [DiRAC's AMD GPU hackathon](https://dirac.ac.uk/training_events/cross-community-amd-gpu-hackathon/) A fully funded 3-day workshop for teams of researchers to work with experts to accelerate their code with GPU computing. Birmingham from **2026-03-11** to **2026-03-13**, register your interest now.
+- [National Federation of Compute Services Survey](https://www.software.ac.uk/news/national-federation-compute-services-survey): What benefits do national to institutional computing resources provide to researchers and service providers? Closes **2026-03-31**.
+- [CAKE DRI Knowledge Exchange Placements and Visits](https://www.cake.ac.uk/about/placements/) Apply for funding to build collaboration and share knowledge-exchange practices. This programme runs until **April 2028**, with applications processed on a monthly basis.peck](mailto:r.speck@fz-juelich.de).
+  - [What is a knowledge exchange placement, and could it help develop your career?](https://www.software.ac.uk/blog/what-knowledge-exchange-placement-and-could-it-help-develop-your-career)
+- [RSEHPC@ISC26 Workshop proposal: AI in parallel software development - Call for Committee] Following the success from the [previous years workshops](https://www.helmholtz-hirse.de/events/2025_06_13-rsehpcatisc.html), we are planning to submit a proposal for a workshop at [next years ISC High Performance conference](https://isc-hpc.com/). For this next workshop, we are planning to focus on the topic of using AI for RSE work in the HPC world, specifically for development of (highly) parallel software. If you would like to join the organising committee for this workshop reach out to [René Caspart](mailto:rene.caspart@kit.edu) and [Robert S
+- The [Repository Crisis Scorecards (RCS) project](http://esipfed.org/rcs) asks a simple but urgent question: How resilient are our data repositories?
+  - Through the RCS, we’re helping repositories, researchers, and communities understand where their strengths lie, where they’re vulnerable, and how to better prepare for disruption, whether from loss of funding, functionality, material, or personnel. [Register interest in the project](https://forms.gle/S6NncgvreHPRBiat6)
+- The [NVIDIA academic grant program](https://www.nvidia.com/en-gb/industries/higher-education-research/academic-grant-program/) is still ongoing, with GPU time and hardware available to suitable research projects. Current calls focus on
+ - Generative AI: Training and Model Development
+ - Generative AI: Alignment and Inference
+ - Robotics and Edge AI
+
+---
+
+## Jobs
+
+- [PhD : FLAME-GPU accelerated agent-based modelling of material response to environmental and operational loading](https://www.findaphd.com/phds/project/flame-gpu-accelerated-agent-based-modelling-of-material-response-to-environmental-and-operational-loading/?p192171)
+  A fully funded PhD opportunity within the Materials 4.0 CDT, working with Prof Paul Richmond of the RSE Team to focus on GPU accelerated agent-based modelling of materials with [FLAME GPU](www.flamegpu.com) (which was developed by members of the RSE Team).
+
+### Community
+
+#### Digital Research Practice Support Community
+
+The DRPS community is a group for people that support researchers in carrying out research in the digital age. Meetings
+are held monthly, with discussions around events, training and opportunities related to the field.
+
+You can join the google group
+[here](https://groups.google.com/u/1/a/sheffield.ac.uk/g/digital-research-practice-support-community-group/about) to
+stay informed.
+
+The next meeting is scheduled for 2pm on Wednesday 2026-01-28.
+
+
+<!-- Not currently active, conflicts with alternatively named RSE Seminar Series
+#### LunchBytes
+
+[LunchBytes][lunchbytes] are short talks from the research community on research
+software, data, and infrastructure.
+
+More information on future LunchBytes will be coming out over the coming months, so sign up to the [RSE mailing
+list](https://groups.google.com/a/sheffield.ac.uk/g/RSE-group) if you'd like to learn more about research software and
+associated practices, or get in contact with [Norbert](mailto:n.g.gyenge@sheffield.ac.uk) if you would like to share
+what you know at an upcoming session!
+-->
+
+### Support
+
+#### Code Clinics
+
+Why not come to a [Code Clinic][CCs]? We're keen to help you.
+
+Code Clinics are fortnightly supported sessions run by the RSE team and IT Services’ [Research
+IT][its-res-it] team. They are open to anyone at TUoS writing code for research to get help with programming problems
+and general advice on best practices.
+
+At each session, members of the RSE and/or Research IT teams will be available to review code, advise, troubleshoot, and
+suggest ways to improve your computational workflows.
+
+#### Research IT HPC Drop In
+
+HPC Drop-In sessions are providing assistance with HPC related user issues such as challenges in scaling an application
+from desktop to supercomputer. We are considering extending the number of our sessions to two or three weekly. These
+interactive sessions could provide a better interface with our users than our non-interactive ticketing system. These
+sessions are advertised on the [HPC mailing list][hpc-mailing].
+
+#### Research IT Consultations
+
+Alongside the HPC Drop-In sessions, Research IT are also running one to one consultations to solve in depth user
+specific problems. These consultations can be booked via our webpage. If you are interested please visit the following
+link: <https://students.sheffield.ac.uk/it-services/research>.
+
+## Sheffield RSE Team
+
+The Sheffield RSE Team aims to [collaborate][rse-service] with you to help improve your research software. They can
+[provide dedicated staff][rse-provision] to ensure that you can deliver excellent research software engineering on your
+research projects.
+
+## Research IT
+
+[Research IT][its-res-it] directly supports research, both academic and commercial.  We provide large scale HPC systems,
+advice on everything from statistics to ML to data pipelines and training for both students and staff.
+
+Working with academics, our staff are embedded within research groups on both long and short term engagements.
+
+[CCs]: https://rse.shef.ac.uk/support/code-clinic/
+[hpc-mailing]: https://groups.google.com/u/1/a/sheffield.ac.uk/g/hpc
+[its-res-it]: https://www.sheffield.ac.uk/it-services/research/
+[lunchbytes]: https://rse.shef.ac.uk/community/lunch-bytes/
+[rse-provision]: https://rse.shef.ac.uk/collaboration/provision/
+[rse-service]: https://rse.shef.ac.uk/collaboration/


### PR DESCRIPTION
Waiting for
- [x] SocRSE Ethical sponsor policy survey (due Monday)
- [x] GPU WG seminar schedule (We have a meeting on Monday)
- [x] My aswell mention project/people team website request.
- [x] Durham HPC days registration
 :mega:Registrations have opened for the [Durham HPC Days](https://hpc-days.github.io/Durham-HPC-Days-2026/) 15-19 June 2026, Durham, UK!
The call for session proposals is also open and closes January 31, 2026. An open call for talks will open early 2026.
