### PR TITLE
Sort team (and alumni) members by surname and othernames only

### DIFF
--- a/pages/contact/alumni.md
+++ b/pages/contact/alumni.md
@@ -18,7 +18,7 @@ placeholder_colours:
 
 Previous members of the RSE Sheffield team:
 
-{% assign people = site.people | sort: 'othernames' | sort: 'surname' | sort: 'level'  %}
+{% assign people = site.people | sort: 'othernames' | sort: 'surname' %}
 {% assign placeholder_idx = 0 %}
 <div class="people-list row">
 {% for person in people %}

--- a/pages/contact/team.md
+++ b/pages/contact/team.md
@@ -18,7 +18,7 @@ placeholder_colours:
 
 Current members of the Research Software Engineering team are listed below. Previous members of the team can be found on our [Alumni](../alumni) page.
 
-{% assign people = site.people | sort: 'othernames' | sort: 'surname' | sort: 'level'  %}
+{% assign people = site.people | sort: 'othernames' | sort: 'surname' %}
 {% assign placeholder_idx = 0 %}
 <div class="people-list row">
 {% for person in people %}


### PR DESCRIPTION
Sort team (and alumni) members by surname and othernames only

Requested by @Romain-Thomas-Shef

(This does make `level` redundant, so could potentially be removed too)

--- 

To be discussed in the next team meeting (2025-01-28)