### PR TITLE
fix(archive): update link to call for propopsals 2024

### DIFF
--- a/pages/archive/index.md
+++ b/pages/archive/index.md
@@ -8,7 +8,7 @@ type: text
 This is a list of archived pages.
 
 - [CMI-RSE call](/collaboration/cmi-rse)
-- [RSE Call for proposals 2024](/collaboration/RSEtime/2024/)
+- [RSE Call for proposals 2024](/archive/cfp2024.md)
 - [Testimonials](/collaboration/testimonials)
 - [Seminar series](/community/seminars)
 - [Lunch Bytes talks](/community/lunch-bytes)


### PR DESCRIPTION
Found the link from `pages/archive/index.md` to the 2024 call for proposals page wasn't working. This updates the target
so clicking on the doesn't return 404.

Closes #988