### PR TITLE
fix(archive): update link to call for propopsals 2024

### DIFF
--- a/pages/archive/index.md
+++ b/pages/archive/index.md
@@ -8,7 +8,7 @@ type: text
 This is a list of archived pages.
 
 - [CMI-RSE call](/collaboration/cmi-rse)
-- [RSE Call for proposals 2024](/collaboration/RSEtime/2024/)
+- [RSE Call for proposals 2024](cfp2024.md)
 - [Testimonials](/collaboration/testimonials)
 - [Seminar series](/community/seminars)
 - [Lunch Bytes talks](/community/lunch-bytes)


### PR DESCRIPTION
Closes #988

Third times a charm (I hope!).

Have built this locally and the link now takes you to the correct page.