### PR TITLE
Fix /survey: use page layout not default

### DIFF
--- a/pages/survey.md
+++ b/pages/survey.md
@@ -1,6 +1,6 @@
 ---
 title: Survey
-layout: default
+layout: page
 permalink: /survey/
 ---
 


### PR DESCRIPTION
Fixes the layout for the `/survey` page

From

<img width="1115" height="180" alt="image" src="https://github.com/user-attachments/assets/091a6ddb-734d-43a7-9055-040eb4101210" />

to

<img width="1170" height="1231" alt="image" src="https://github.com/user-attachments/assets/cc6af98f-143f-4be9-91ff-e9b2408fcb46" />
