### PR TITLE
Archived the deep learning intro page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -47,5 +47,3 @@
        url: /learning/fair4rs
      - title: Profiling and Optimisation (Python) [Training]
        url: /learning/pando-python
-     - title: Introduction to Deep Learning [Training]
-       url: /learning/deep-learning

--- a/pages/archive/deep-learning.md
+++ b/pages/archive/deep-learning.md
@@ -5,6 +5,8 @@ type: text
 permalink: /learning/deep-learning
 ---
 
+<div class="alert alert-danger" role="alert"> This page has been archived and is retained solely for reference purposes.</div>
+
 Can be delivered for **Python** or **R**.
 
 **Prerequisite skills:** Basic **Python** or **R**.

--- a/pages/archive/index.md
+++ b/pages/archive/index.md
@@ -13,3 +13,4 @@ This is a list of archived pages.
 - [Seminar series](/community/seminars)
 - [Lunch Bytes talks](/community/lunch-bytes)
 - [Researcher AI and ML Resources](/training/deeplearning)
+- [Introduction to Deep Learning](/learning/deep-learning)


### PR DESCRIPTION
Closes #1009. Moved the "Introduction to Deep Learning" page to archive. I did consider deleting it altogether, but it might be good to keep the link to the course material in case any previous attendees still want to access it.