### PR TITLE
chore: Update windows platform in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :jekyll_plugins do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:windows, :jruby]
 
 # Proofer for testing HTML output
 gem "html-proofer"


### PR DESCRIPTION
Closes #1016

As per output when running `bundle install`

```
[DEPRECATED] Platform :mingw, :mswin, :x64_mingw will be removed in the future. Please use platform :windows instead.
```

This removes deprecated platforms and instead uses `:windows`