### PR TITLE
ci: Update github actions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -14,7 +14,7 @@ jobs:
       USE_HTMLPROOFER: '0'
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Install Ruby
       - name: Install Ruby
@@ -47,7 +47,7 @@ jobs:
       # Store the list of potentially broken links
       - name: Archive log links
         if: ${{ env.USE_HTMLPROOFER == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: links-check.log
           path: links.log

--- a/.github/workflows/pa11y.yaml
+++ b/.github/workflows/pa11y.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Install Ruby
       - name: Install Ruby

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Install Ruby
       - name: Install Ruby
@@ -53,7 +53,7 @@ jobs:
 
       # Save HTML for later
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site/
 
@@ -69,8 +69,8 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
-  
+        uses: actions/deploy-pages@v5
+
   # Trigger the build of the rse.sheffield.ac.uk mirror
   mirror:
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) && github.ref == 'refs/heads/master' && github.repository_owner == 'RSE-Sheffield' }}


### PR DESCRIPTION
Closes #1044

There were two actions which were outdated and using old versions of Node.js.

Also bumping other outdated actions.