### PR TITLE
Add Call for Proposals 2026 to front page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,10 +45,16 @@ layout: default
                 <p><a class="sm-a" href="mailto:rse@sheffield.ac.uk">Add fractional RSE time from the team to your
                         funding application <br> (email rse@sheffield.ac.uk).</a></p>
             </div>
+            <!-- <div class="col-md text-center"> -->
+            <!--     <h2 style="color: white">FAIR² for research software</h2> -->
+            <!--     <p><a class="sm-a" href="/training/fair4rs">Dedicated training on how to apply FAIR principles to -->
+            <!--             research software, enabling you to make your research more open.</a></p> -->
+            <!-- </div> -->
+
             <div class="col-md text-center">
-                <h2 style="color: white">FAIR² for research software</h2>
-                <p><a class="sm-a" href="/training/fair4rs">Dedicated training on how to apply FAIR principles to
-                        research software, enabling you to make your research more open.</a></p>
+                <h2 style="color: white">Call for Proposals 2026</h2>
+                <p><a class="sm-a" href="/collaboration/RSEtime/2026">Apply for 6 months 50% FTE of RSE support to
+                improve your software.</a></p>
             </div>
 
             <div class="col-md text-center">


### PR DESCRIPTION
Substitutes the FAIR^2 link for the current open Call for Proposals.

I figured that as the FAIR^2 training for this year has been completed it wouldn't do any harm having it replaced by the
Call for Proposals.

To which end I commented out the FAIR^2 section so it can easily be reinstated once the current call closes.