### PR TITLE
Revise learning pages and learning section navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -43,6 +43,7 @@
        url: /learning/fair4rs
      - title: Profiling & Optimisation (Python)
        url: /learning/pando-python
+       target: blank
      - title: Parallel Computing with GPUs
        url: /learning/com4521
      - title: MADE4Manufacturing CDT

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,5 +45,5 @@
        url: /learning/pando-python
      - title: Parallel Computing with GPUs
        url: /learning/com4521
-     - title: MADE4Manufacturing CDT #Data Science and Software Engineering in Manufacturing
+     - title: MADE4Manufacturing CDT
        url: /learning/mac4112

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -37,11 +37,13 @@
 
 - title: "Learning"
   subitems:
-     - title: Parallel Computing with GPUs [Academic Module]
-       url: /learning/com4521
-     - title: Data Science and Software Engineering in Manufacturing
-       url: /learning/mac4112
-     - title: FAIR² for Research Software [Training]
+     - title: Training and teaching
+       url: /learning/index
+     - title: FAIR² for Research Software
        url: /learning/fair4rs
-     - title: Profiling and Optimisation (Python) [Training]
+     - title: Profiling & Optimisation (Python)
        url: /learning/pando-python
+     - title: Parallel Computing with GPUs
+       url: /learning/com4521
+     - title: MADE4Manufacturing CDT #Data Science and Software Engineering in Manufacturing
+       url: /learning/mac4112

--- a/_includes/events_list_upcoming.html
+++ b/_includes/events_list_upcoming.html
@@ -20,6 +20,6 @@
     {% endif %}
 {% endfor %}
 {% unless event_exists %}
-    No events are currently scheduled, please join our <a href="https://groups.google.com/a/sheffield.ac.uk/g/rse-group">mailing list</a> to hear about new events.
+    <p>No events are currently scheduled, please join our <a href="https://groups.google.com/a/sheffield.ac.uk/g/rse-group">mailing list</a> to hear about new events.</p>
 {% endunless %}
 </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,8 +6,9 @@
             {% if lv1.subitems %}
             <div class="dropdown-menu">
                 {% for lv2 in lv1.subitems %}
-                <a class="dropdown-item" href="{% if lv2.url %}{{ lv2.url }}{% else %}#{% endif %}">
+                <a class="dropdown-item" href="{% if lv2.url %}{{ lv2.url }}{% else %}#{% endif %}" {% if lv2.target == 'blank' %}target="_blank"{% endif %}>
                     {{ lv2.title }}
+                    {% if lv2.target == 'blank' %}<i class="fas fa-external-link-square-alt nav-icon" aria-label="External link"></i>{% endif %}
                 </a>
                 {% endfor %}
             </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -56,6 +56,10 @@ a {
     color: var(--uos-midnight-black) !important;
 }
 
+.nav-icon{
+    color: var(--uos-brand-violet-70);
+}
+
 .contact {
     background: var(--uos-midnight-black);
 }

--- a/pages/learning/index.md
+++ b/pages/learning/index.md
@@ -72,7 +72,7 @@ We can also run courses where material is made openly available by others (e.g. 
 Carpentries][carpentries]). If you’re interested in us running similar courses for your learners,
 please contact [rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk).
 
-## Teaching
+## Academic teaching
 
 Members of the RSE Team lead and co-lead the following Masters’ and PhD level academic modules
 within the university:

--- a/pages/learning/index.md
+++ b/pages/learning/index.md
@@ -1,74 +1,88 @@
 ---
-title: Training
+title: Training and teaching
 layout: page
 slug: index
 type: text
-permalink: /training/
+permalink: /learning/
 ---
 
-People working with code for research, whether they are writing their first script to managing a complex software
-project need skills that academic training might not provide. The RSE Team's aspiration is that all researchers who need
-these skills should be given the opportunity to learn them, either from the RSE Team, our University of Sheffield
-colleagues or other sources.
+The RSE Team participates in a wide range of training and teaching activities. We provide training
+for people who work with code for research to build their skills in areas that academic training
+might not provide. We have developed training courses for the University of Sheffield which have
+been recognised and adopted by external organisations. Additionally, we lead and co-lead academic
+modules at undergraduate and PhD levels within the university.
 
-### Regular RSE Team Training
+## Training
 
-The RSE Team focusses on training in version control as this is a key skill for reproducible research and collaborative
-software development. We have recently introduced a programme of FAIR and reproducible software skills for
-researchers. We also offer training in Deep Learning to improve and facilitate update of AI. These courses are run on a
-regular basis. If there are not courses currently advertised, check back soon, or [join our
-mailing](https://groups.google.com/a/sheffield.ac.uk/g/rse-group) list to find out when new courses are advertised.
+The RSE Team’s core training programme centres around improving and optimising research software
+through software engineering best practices such as version control, software design, testing and
+profiling. By providing researchers with opportunities to learn these key skills for reproducible
+research and collaborative software development we hope to empower researchers to create good
+quality, efficient and sustainable research software.
 
-- [git & GitHub through GitKraken - from Zero to Hero!](courses/git_Hero.md)
-- [Introduction to Deep Learning](courses/Intro_DL.md)
-- [Performance Profiling & Optimisation (Python)](/pando-python)
-- [FAIR<sup>2</sup> for research software](fair4rs)
+The following courses are run on a regular basis:
+
+- [FAIR<sup>2</sup> for Research Software](/learning/fair4rs)
+- [Performance Profiling & Optimisation (Python)](/learning/pando-python)
+
+We also offer training in Deep Learning to improve and facilitate uptake of AI.
+
+[Join our mailing list](https://groups.google.com/a/sheffield.ac.uk/g/rse-group) to find out when
+new courses are advertised.
 
 #### Upcoming training
 
-{% include events_list_upcoming.html category="workshop,carpentry,gitzerohero,dltraining" %}
+{% include events_list_upcoming.html category="workshop,carpentry,gitzerohero,dltraining,fair4rs" %}
 
 ### IT Services Training
 
-Our colleagues in [IT Services][its] offer a range of [free training courses][its-courses]. This is a good place to look
-if you want to learn how to code, but there are a wide range of other courses there as well.
-
-### Responsive RSE Team Training
-
-The RSE Team run training in response to the needs of groups of researchers. However, we usually need to seek funding
-from an organisation, department, research group, institute or doctoral training centre. The costs of running a course
-are our [staff time][service] plus venue and infrastructure costs. This allows us to customise or develop new training
-for specific audiences.
-
-We have recently run these courses:
-
-- [Reproducible Research Data and Project Management in R](courses/ACCE.md)
-- [Contributing to Open Source Software](courses/Open_Source.md)
-- [Write better research software (in Python)](courses/good_soft.md)
-
-Our expertise for bespoke training development includes Python, R, MATLAB, Reproducible research, C and C++, Git and
-GitHub, Linux shell, High Performance Computing, GPU Computing, Systems administration inc. Docker and Ansible.
-
-We can run courses where material is made openly available by others (e.g. [The Carpentries](https://carpentries.org)).
-
-If you're interested in us running similar courses for your learners, please contact <rse@sheffield.ac.uk>.
+Our colleagues in [IT Services][its] offer a range of [free training courses][its-courses] in
+programming, AI, high performance computing and data science.
 
 ### Statement on free at point of use training
 
-We are delighted to be able to make free at point of use training available to the research community, to enable better
-software and more open, reproducible research. However, **free at point of use training is not free**. The cost of a
-course can easily run to thousands of pounds, if preparation costs are taken into account.
+We are delighted to be able to make free at point of use training available to the research
+community, to enable better software and more open, reproducible research. However, **free at point
+of use training is not free**. The cost of a course can easily run to thousands of pounds, if
+preparation costs are taken into account.
 
-**If you sign up for a course, please make sure you either attend or cancel your booking.** Bookings can usually be
-cancelled using [myDevelopment][my-development] (log-in required) or, failing that, by emailing
-[rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk).
+**If you sign up for a course, please make sure you either attend or cancel your booking**. Bookings
+can usually be cancelled using [myDevelopment][my-development] (log-in required) or, failing that,
+by emailing [rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk).
 
-Running courses that are not fully attended wastes our funding (which is provided by taxpayers, charities and students,
-amongst others) and reduces our collective capacity to improve research outputs and researcher experiences.
+Running courses that are not fully attended wastes our funding (which is provided by taxpayers,
+charities and students, amongst others) and reduces our collective capacity to improve research
+outputs and researcher experiences.
 
-Persistent failure to attend booked courses might result in you being excluded from future training opportunities.
+Persistent failure to attend booked courses might result in you being excluded from future training
+opportunities.
+
+### Bespoke training
+
+We can provide bespoke training in response to the needs of groups of researchers. However, we
+usually need to seek funding from an organisation, school, research group, institute or doctoral
+training centre. The costs of running a course are our staff time plus venue and infrastructure
+costs. Covering these costs allows us to customise or develop new training for specific audiences.
+
+<!-- Our expertise for bespoke training development includes Python, R, MATLAB, Reproducible research, C
+<!-- and C++, Git and GitHub, Linux shell, High Performance Computing, GPU Computing, Systems
+<!-- administration inc. Docker and Ansible. -->
+
+We can also run courses where material is made openly available by others (e.g. [The
+Carpentries][carpentries]). If you’re interested in us running similar courses for your learners,
+please contact [rse@sheffield.ac.uk](mailto:rse@sheffield.ac.uk).
+
+## Teaching
+
+Members of the RSE Team lead and co-lead the following Masters’ and PhD level academic modules
+within the university:
+
+- [Parallel Computing with GPUs](/learning/com4521) (COM4521/COM6521)
+- [Data Science and Software Engineering in Manufacturing](/learning/mac4112) (MAC4112)
+
+<br>
 
 [my-development]: https://mydevelopment.csod.com/ui/lms-learner-home/home
 [its-courses]: https://www.sheffield.ac.uk/it-services/research/one-day-sessions
 [its]: https://www.sheffield.ac.uk/it-services/research
-[service]: ../service/index.md
+[carpentries]: https://carpentries.org

--- a/pages/learning/parallel_com_with_GPU.md
+++ b/pages/learning/parallel_com_with_GPU.md
@@ -1,5 +1,5 @@
 ---
-title: Parallel Computing with GPUs [Academic module]
+title: Parallel Computing with GPUs
 permalink: /learning/com4521/
 slug: com4521
 type: page


### PR DESCRIPTION
Address outstanding issues in #1004 

- Add cleaned up version of main training page
- Shorten text in navigation menu
- Tidy up formatting in upcoming events template
- Amend GPU page heading