### PR TITLE
Fix redirect_from plugin

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    {% if page.redirect -%}
-    <meta http-equiv="refresh" content="0; url={{ page.redirect }}">
+    {% if page.redirect.to != blank %}
+        {% assign redirect_dest = page.redirect.to %}
+    {% elsif page.redirect != blank %}
+        {% assign redirect_dest = page.redirect %}
+    {% endif %}
+    {% if redirect_dest != blank -%}
+    <meta http-equiv="refresh" content="0; url={{ redirect_dest | escape}}">
     <script type="text/javascript">
-        window.location.href = "{{ page.redirect }}"
+        window.location.href = "{{ redirect_dest | escape}}"
     </script>
     {%- endif -%}
     <title>{{ site.title }} {% if page.title %} - {{ page.title }}{% endif %}</title>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,5 +1,9 @@
 ---
 layout: page
 ---
-<!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-If you are not redirected automatically, follow this <a href='{{ page.redirect }}'>link</a>.
+{% if page.redirect.to != blank %}
+    {% assign redirect_dest = page.redirect.to %}
+{% elsif page.redirect != blank %}
+    {% assign redirect_dest = page.redirect %}
+{% endif %}
+If you are not redirected automatically, follow this <a href='{{ redirect_dest | escape}}'>link</a>.


### PR DESCRIPTION
This was broken by the custom _layouts/redirect.html to redirect to external pages, which used page.redirect while redirect_from used page.redirect.to/from.

Also escapes the URL to encode quotes etc if they are in the link (for some reason).

Closes #966

---

(Could probably have just switched the one `redirect:` page to `redirect_to` instead of supporting both): 

This has only been tested locally, and not on hosted github pages (but it should be fine?).