### PR TITLE
Close 2026 Call and revert front page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,18 +45,11 @@ layout: default
                 <p><a class="sm-a" href="mailto:rse@sheffield.ac.uk">Add fractional RSE time from the team to your
                         funding application <br> (email rse@sheffield.ac.uk).</a></p>
             </div>
-            <!-- <div class="col-md text-center"> -->
-            <!--     <h2 style="color: white">FAIR² for research software</h2> -->
-            <!--     <p><a class="sm-a" href="/training/fair4rs">Dedicated training on how to apply FAIR principles to -->
-            <!--             research software, enabling you to make your research more open.</a></p> -->
-            <!-- </div> -->
-
             <div class="col-md text-center">
-                <h2 style="color: white">Call for Proposals 2026</h2>
-                <p><a class="sm-a" href="/collaboration/RSEtime/2026">Apply for 6 months 50% FTE of RSE support to
-                improve your software.</a></p>
+                <h2 style="color: white">FAIR² for research software</h2>
+                <p><a class="sm-a" href="/training/fair4rs">Dedicated training on how to apply FAIR principles to
+                        research software, enabling you to make your research more open.</a></p>
             </div>
-
             <div class="col-md text-center">
                 <h2 style="color: white">Code Clinics</h2>
                 <p><a class="sm-a" href="/support/code-clinic">Work with an expert for 30 mins on your code.</a></p>

--- a/pages/collaboration/RSEtime/2026/call.md
+++ b/pages/collaboration/RSEtime/2026/call.md
@@ -5,7 +5,7 @@ slug: index
 type: text
 ---
 
-**UPDATE** The deadline for submissions has been extended by a week and is now 21st July 2026.
+<div class="alert alert-danger" role="alert"> This call concluded in July 2026. A new call is expected to open in June 2027.</div>
 
 ### Rationale
 


### PR DESCRIPTION
- Red banner to the 2026 Call for Proposals indicating that it has closed.
- Remove link from front page, reinstating FAIR^2 For Research Software.