### PR TITLE
Fix redirect_from plugin (against rebased branch)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    {% if page.redirect -%}
-    <meta http-equiv="refresh" content="0; url={{ page.redirect }}">
+    {% if page.redirect.to != blank %}
+        {% assign redirect_dest = page.redirect.to %}
+    {% elsif page.redirect != blank %}
+        {% assign redirect_dest = page.redirect %}
+    {% endif %}
+    {% if redirect_dest != blank -%}
+    <meta http-equiv="refresh" content="0; url={{ redirect_dest | escape}}">
     <script type="text/javascript">
-        window.location.href = "{{ page.redirect }}"
+        window.location.href = "{{ redirect_dest | escape}}"
     </script>
     {%- endif -%}
     <title>{{ site.title }} {% if page.title %} - {{ page.title }}{% endif %}</title>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,5 +1,9 @@
 ---
 layout: page
 ---
-<!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-If you are not redirected automatically, follow this <a href='{{ page.redirect }}'>link</a>.
+{% if page.redirect.to != blank %}
+    {% assign redirect_dest = page.redirect.to %}
+{% elsif page.redirect != blank %}
+    {% assign redirect_dest = page.redirect %}
+{% endif %}
+If you are not redirected automatically, follow this <a href='{{ redirect_dest | escape}}'>link</a>.

--- a/pages/archive/cfp2025.md
+++ b/pages/archive/cfp2025.md
@@ -3,6 +3,8 @@ title: Call for Proposal - RSE collaboration 2025 [Closed]
 permalink: /opportunities/cfp/
 slug: index
 type: text
+redirect_from:
+    - /collaboration/RSEtime/2025/index
 ---
 
 <div class="alert alert-danger" role="alert"> This call concluded in July 2025. A new call is expected to open in June 2026.</div>

--- a/pages/archive/com4521/hpc-sharc.md
+++ b/pages/archive/com4521/hpc-sharc.md
@@ -9,6 +9,8 @@ category:
 link:
 description:
 type: text
+redirect_from:
+    - /training/com4521/hpc-sharc
 ---
 
 This page documents how the [ShARC](https://docs.hpc.shef.ac.uk/en/latest/sharc/index.html) HPC cluster can be used by COM4521/COM6521 students, this is predominantly to enable remote work on the assignment during the Easter break, however lab solutions are provided with a makefile which could be updated to work on HPC too.

--- a/pages/archive/com4521/labs/1.md
+++ b/pages/archive/com4521/labs/1.md
@@ -9,6 +9,8 @@ category:
 link:
 description:
 type: text
+redirect_from:
+    - /training/com4521/labs/1
 ---
 
 # Lab 1 - FAQ

--- a/pages/archive/com4521/labs/2.md
+++ b/pages/archive/com4521/labs/2.md
@@ -9,6 +9,8 @@ category:
 link:
 description:
 type: text
+redirect_from:
+    - /training/com4521/labs/2
 ---
 
 # Lab 2 - FAQ

--- a/pages/archive/com4521/labs/3.md
+++ b/pages/archive/com4521/labs/3.md
@@ -9,6 +9,8 @@ category:
 link:
 description:
 type: text
+redirect_from:
+    - /training/com4521/labs/3
 ---
 
 # Lab 3 - FAQ

--- a/pages/archive/com4521/labs/4.md
+++ b/pages/archive/com4521/labs/4.md
@@ -9,6 +9,8 @@ category:
 link:
 description:
 type: text
+redirect_from:
+    - /training/com4521/labs/4
 ---
 
 # Lab 3 - FAQ

--- a/pages/collaboration/code-of-conduct.md
+++ b/pages/collaboration/code-of-conduct.md
@@ -1,6 +1,8 @@
 ---
 title: Code of Conduct
 permalink: /collaboration/code-of-conduct
+redirect_from:
+    - /community/code_of_conduct
 type: text
 ---
 

--- a/pages/collaboration/collab-guide.md
+++ b/pages/collaboration/collab-guide.md
@@ -1,6 +1,11 @@
 ---
 title: Research collaborations
 permalink: /collaboration/collab-guide/
+redirect_from:
+    - /collaboration/
+    - /collaboration/provision/
+    - /collaboration/activities/
+    - /collaboration/costing/
 slug: evidence
 type: text
 ---

--- a/pages/learning/fair4rs.md
+++ b/pages/learning/fair4rs.md
@@ -3,6 +3,8 @@ title: FAIR² for research software
 layout: page
 type: text
 permalink: /learning/fair4rs/
+redirect_from:
+    - /training/fair4rs/
 ---
 
 ## Introduction and target audience

--- a/pages/learning/index.md
+++ b/pages/learning/index.md
@@ -6,6 +6,8 @@ type: text
 permalink: /learning/
 redirect_from:
     - /training/
+    - /training/intel/index
+    - /training/programming
 ---
 
 The RSE Team participates in a wide range of training and teaching activities. We provide training

--- a/pages/learning/index.md
+++ b/pages/learning/index.md
@@ -4,6 +4,8 @@ layout: page
 slug: index
 type: text
 permalink: /learning/
+redirect_from:
+    - /training/
 ---
 
 The RSE Team participates in a wide range of training and teaching activities. We provide training

--- a/pages/learning/index.md
+++ b/pages/learning/index.md
@@ -8,6 +8,12 @@ redirect_from:
     - /training/
     - /training/intel/index
     - /training/programming
+    - /training/COM605/index
+    - /pages/training/courses/good_soft
+    - /pages/training/courses/git_Hero
+    - /pages/training/courses/Open_Source
+    - /pages/training/courses/Intro_DL
+    - /pages/training/courses/ACCE
 ---
 
 The RSE Team participates in a wide range of training and teaching activities. We provide training

--- a/pages/learning/parallel_com_with_GPU.md
+++ b/pages/learning/parallel_com_with_GPU.md
@@ -3,6 +3,8 @@ title: Parallel Computing with GPUs
 permalink: /learning/com4521/
 slug: com4521
 type: page
+redirect_from:
+    - /training/com4521/
 ---
 
 Parallel Computing with GPUs ([COM4521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/level4/com4521.html)/[COM6521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/msc/com6521.html)) is a 4th/MSc level academic module within the school of Computer Science, led by [Robert Chisholm](/contact/robert-chisholm/) from the RSE team.

--- a/pages/learning/parallel_com_with_GPU.md
+++ b/pages/learning/parallel_com_with_GPU.md
@@ -5,6 +5,11 @@ slug: com4521
 type: page
 redirect_from:
     - /training/com4521/
+    - /training/com4521/hpc-sharc
+    - /training/com4521/labs/1
+    - /training/com4521/labs/2
+    - /training/com4521/labs/3
+    - /training/com4521/labs/4
 ---
 
 Parallel Computing with GPUs ([COM4521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/level4/com4521.html)/[COM6521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/msc/com6521.html)) is a 4th/MSc level academic module within the school of Computer Science, led by [Robert Chisholm](/contact/robert-chisholm/) from the RSE team.

--- a/pages/learning/parallel_com_with_GPU.md
+++ b/pages/learning/parallel_com_with_GPU.md
@@ -5,11 +5,6 @@ slug: com4521
 type: page
 redirect_from:
     - /training/com4521/
-    - /training/com4521/hpc-sharc
-    - /training/com4521/labs/1
-    - /training/com4521/labs/2
-    - /training/com4521/labs/3
-    - /training/com4521/labs/4
 ---
 
 Parallel Computing with GPUs ([COM4521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/level4/com4521.html)/[COM6521](https://www.dcs.shef.ac.uk/intranet/teaching/public/modules/msc/com6521.html)) is a 4th/MSc level academic module within the school of Computer Science, led by [Robert Chisholm](/contact/robert-chisholm/) from the RSE team.

--- a/pages/opportunities/cfp2026.md
+++ b/pages/opportunities/cfp2026.md
@@ -3,6 +3,8 @@ title: Call for Proposal - RSE collaboration 2026
 permalink: /opportunities/cfp2026
 slug: index
 type: text
+redirect_from:
+    - /collaboration/RSEtime/2026/
 ---
 
 **UPDATE** The deadline for submissions has been extended by a week and is now 21st July 2026.

--- a/pages/opportunities/code-clinic.md
+++ b/pages/opportunities/code-clinic.md
@@ -4,6 +4,8 @@ permalink: /opportunities/code-clinic/
 title: Code Clinic
 slug: code-clinic
 type: text
+redirect_from:
+    - /support/code-clinic/
 ---
 
 ### Stop wasting valuable time trying to fix issues on your own.

--- a/pages/opportunities/events.md
+++ b/pages/opportunities/events.md
@@ -2,6 +2,9 @@
 title: RSE events organised at the University of Sheffield
 layout: page
 permalink: /opportunities/events/
+redirect_from:
+    - /events/
+
 ---
 
 {% include events_list.html %}

--- a/pages/opportunities/forge.md
+++ b/pages/opportunities/forge.md
@@ -3,6 +3,8 @@ title: RSE FORGE Calls
 permalink: /opportunities/forge
 slug: index
 type: text
+redirect_from:
+    - /collaboration/RSEtime/forge
 ---
 
 The RSE FORGE (FOcused Research software Guidance and Enhancement) programme delivers targeted improvements to research software through intensive two day projects. Each project pairs two RSEs who work full time for two days on your research software. FORGE is designed for researchers with functional code who want to tackle/identify performance issues, improve code structure, package their software for publication, or get an expert review. Projects are free and available to all active research staff at the University of Sheffield.

--- a/pages/opportunities/gh-enterprise.md
+++ b/pages/opportunities/gh-enterprise.md
@@ -3,6 +3,8 @@ title: Github Enterprise Early Access Program
 permalink: /opportunities/github-enterprise/
 slug: github-enterprise
 type: text
+redirect_from:
+    - /training/github-enterprise/
 ---
 
 In collaboration with IT Services, the RSE team is providing limited early access to the University's Github Enterprise.


### PR DESCRIPTION
This was broken by the custom _layouts/redirect.html to redirect to external pages, which used page.redirect while redirect_from used page.redirect.to/from.

Also escapes the URL to encode quotes etc if they are in the link (for some reason).

Closes #966