### PR TITLE
Team: Add links/extra_links for Paul Richmond who is no longer alumni

### DIFF
--- a/_people/paul-richmond.md
+++ b/_people/paul-richmond.md
@@ -8,11 +8,27 @@ surname: Richmond
 role: Former Group Director
 image: /assets/images/team/paul-richmond.jpg
 links:
+    - url: "mailto:p.richmond@sheffield.ac.uk"
+      icon: 
+        class: "fas fa-envelope"
+        a11y: "Email"
+      label: "p.richmond@sheffield.ac.uk"
+    - url: "https://github.com/mondus"
+      icon:
+        class: "fab fa-github"
+        a11y: "GitHub"
+      label: "@mondus"
+    - url: "https://orcid.org/0000-0002-4657-5518"
+      image:
+        src: "/assets/images/ORCID-iD_icon_vector.svg"
+        a11y: "ORCID iD"
+      label: 0000-0002-4657-5518
 extra_links:
-
+    - url: "https://paulrichmond.shef.ac.uk/"
+      icon:
+        class: "fas fa-link"
+        a11y: "Link"
+      label: "Personal Website"
 ---
 
 Paul was a co-founder of the RSE team and led its growth and development from three staff to a team of roughly 12 full time employees over a period of six years. He left the RSE Sheffield team in 2023 to become the RSE team lead at the [Cambridge Institute of Computing for Climate Science](https://cambridge-iccs.github.io/), but holds a part time role at the University of Sheffield as a Professor of Research Software Engineering in the Department of Computer Science. He no longer oversees the RSE team but is actively engaged in research projects and impact work relating to the application of research software, in particular the [FLAME GPU](http://www.flamegpu.com) software for GPU accelerated agent based simulation. Paul was formally an [EPSRC Research Software Engineering Fellow](https://rse.ac.uk/community/epsrc-rse-fellows/) and [President of the society of Research Software Engineering](https://society-rse.org/about/governance/rse-society-trustees-2020-2021/). He is actively engaged in the national RSE community and retains interest in advancing the national provision of RSE collaboration including within the University of Sheffield.
-
-* Email: P.Richmond (at) Sheffield.ac.uk
-* Web: [http://paulrichmond.shef.ac.uk](http://paulrichmond.shef.ac.uk)


### PR DESCRIPTION
In the `new_website_rebase` branch, Paul has been marked as a current member of the team not alumni, without other changes. 

This adds the `links` and `extra_links` content to the frontmatter to match other active team members. 

The bio content itself is still out of date.